### PR TITLE
feat: base icon component create

### DIFF
--- a/lib/presentation/component/base_icon.dart
+++ b/lib/presentation/component/base_icon.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class BaseIcon extends StatelessWidget {
+  final Color iconColor;
+  final IconData iconData;
+  final double size;
+  const BaseIcon({
+    super.key,
+    required this.iconColor,
+    required this.iconData,
+    required this.size,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return CircleAvatar(
+      maxRadius: size,
+      backgroundColor: iconColor.withValues(alpha: 0.1),
+      child: Icon(iconData, color: iconColor, size: 18),
+    );
+  }
+}

--- a/lib/presentation/component/base_icon.dart
+++ b/lib/presentation/component/base_icon.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+/// size 의 경우 반지름으로 적용되기 때문에 일반적인 크기보다 반으로 줄여서 입력해주세요.
 class BaseIcon extends StatelessWidget {
   final Color iconColor;
   final IconData iconData;

--- a/test/presentation/component/base_icon_test.dart
+++ b/test/presentation/component/base_icon_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:photopin/core/styles/app_color.dart';
+import 'package:photopin/presentation/component/base_icon.dart';
+
+void main() {
+  group('base icon 컴포넌트 테스트', () {
+    testWidgets('제대로 생성되어야 한다.', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: BaseIcon(
+            iconColor: AppColors.primary100,
+            size: 20,
+            iconData: CupertinoIcons.link,
+          ),
+        ),
+      );
+
+      final Finder finder = find.byIcon(CupertinoIcons.link);
+
+      expect(finder, findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## 🔍 개요 (Summary)

- 여러 위젯에서 쓰일 icon 생성

---

## ✅ 변경 사항 (Changes)

- base icon component 생성
    - lib/presentation/component
        - base_icon.dart
  
---

## 📸 스크린샷 (Screenshots, 선택사항)

![image](https://github.com/user-attachments/assets/0d3c7ce2-5a17-44f1-a3df-d25d047b09f3)

---

## 🔗 관련 이슈 (Related Issues)

- #20 

---

## 🧪 테스트 (Test)

- [x] 컴포넌트가 정상적으로 생성되어야한다.

## 📝 참고 사항 (Notes)

- 옵션으로 받는 size 의 경우 반지름 값이기 때문에 정상 값보다 반 적은 값을 입려해야합니다.

---

## 👀 리뷰어 체크리스트 (For Reviewer)

- [x] 기능이 명세에 맞게 동작하는지 확인
- [x] 불필요한 코드/주석이 없는지 확인
- [x] 테스트가 적절히 작성되었는지 확인
