### PR TITLE
#39 map_bottom_sheet 컴포넌트

### DIFF
--- a/lib/core/extensions/datetime_extension.dart
+++ b/lib/core/extensions/datetime_extension.dart
@@ -55,4 +55,8 @@ extension DatetimeExtension on DateTime {
   String formDateString() {
     return '${_monthAbbr(month)} $day';
   }
+
+  String formMeridiem() {
+    return hour >= 12 ? 'PM' : 'AM';
+  }
 }

--- a/lib/presentation/component/map_bottom_sheet.dart
+++ b/lib/presentation/component/map_bottom_sheet.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart';
+import 'package:photopin/core/enums/button_type.dart';
+import 'package:photopin/core/styles/app_color.dart';
+import 'package:photopin/core/styles/app_font.dart';
+import 'package:photopin/presentation/component/base_icon.dart';
+import 'package:photopin/core/extensions/datetime_extension.dart';
+import 'package:photopin/presentation/component/base_icon_button.dart';
+
+/// showModalBottomSheet() 함수를 사용하여 띄울 수 있는 모달 바텀 시트입니다.
+/// 기본적으로 showModalBottomSheet의 isDismissible 속성을 반드시 false로 설정해야 [onClosing]과 [onTapClose] 호출이 보장됩니다.
+/// [onClosing] 인자는 바텀 시트가 닫히기 전, 어떤 동작을 해야할 때 사용되며 [onTapClose] 인자는 [onClosing]이 호출된 후에 실행됩니다.
+class MapBottomSheet extends StatelessWidget {
+  final String title;
+  final String imageUrl;
+  final DateTime dateTime;
+  final String location;
+  final String comment;
+
+  final VoidCallback onTapClose;
+  final VoidCallback onTapEdit;
+  final VoidCallback onTapShare;
+  final VoidCallback? onClosing;
+
+  const MapBottomSheet({
+    super.key,
+    required this.title,
+    required this.imageUrl,
+    required this.dateTime,
+    required this.location,
+    required this.comment,
+    required this.onTapClose,
+    required this.onTapEdit,
+    required this.onTapShare,
+    this.onClosing,
+  });
+
+  String _formattedDateTime() =>
+      '${dateTime.formDateString()}, ${dateTime.year} • ${dateTime.hour}:${dateTime.minute} ${dateTime.formMeridiem()}';
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomSheet(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      backgroundColor: AppColors.white,
+      builder: (context) {
+        return SingleChildScrollView(
+          padding: EdgeInsets.only(
+            left: 16,
+            top: 16,
+            right: 16,
+            bottom: 16 + MediaQuery.of(context).viewPadding.bottom,
+          ),
+          child: Column(
+            spacing: 16,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Text(
+                    title,
+                    style: AppFonts.mediumTextBold.copyWith(
+                      color: AppColors.textColor,
+                    ),
+                  ),
+                  const Spacer(),
+                  GestureDetector(
+                    onTap: () {
+                      onClosing?.call();
+                      onTapClose();
+                    },
+                    child: Icon(Icons.close, size: 20, color: AppColors.gray2),
+                  ),
+                ],
+              ),
+              AspectRatio(
+                // TODO: 현재는 고정으로 16:9 비율, 추후 카메라 기능 들어오면 수정
+                aspectRatio: 16 / 9,
+                child: Container(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(10),
+                    image: DecorationImage(
+                      image: NetworkImage(imageUrl),
+                      fit: BoxFit.cover,
+                    ),
+                  ),
+                ),
+              ),
+              Column(
+                spacing: 12,
+                children: [
+                  Row(
+                    spacing: 12,
+                    children: [
+                      BaseIcon(
+                        iconColor: AppColors.primary80,
+                        size: 16,
+                        iconData: Icons.calendar_month,
+                      ),
+                      Text(
+                        _formattedDateTime(),
+                        style: AppFonts.smallTextRegular,
+                      ),
+                    ],
+                  ),
+                  Row(
+                    spacing: 12,
+                    children: [
+                      BaseIcon(
+                        iconColor: AppColors.secondary100,
+                        size: 16,
+                        iconData: Icons.location_on,
+                      ),
+                      Text(location, style: AppFonts.smallTextRegular),
+                    ],
+                  ),
+                  Row(
+                    children: [
+                      BaseIcon(
+                        iconColor: AppColors.primary80,
+                        size: 16,
+                        iconData: Icons.comment,
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Text(
+                          comment,
+                          softWrap: true,
+                          style: AppFonts.smallTextRegular,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              Row(
+                spacing: 12,
+                children: [
+                  Expanded(
+                    child: BaseIconButton(
+                      buttonType: ButtonType.small,
+                      buttonColor: AppColors.primary100,
+                      iconName: Icons.edit,
+                      buttonName: 'Edit',
+                      onClick: onTapEdit,
+                    ),
+                  ),
+                  Expanded(
+                    child: BaseIconButton(
+                      buttonType: ButtonType.small,
+                      buttonColor: AppColors.secondary100,
+                      iconName: Icons.share,
+                      buttonName: 'Share',
+                      onClick: onTapShare,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+      },
+      onClosing: () {},
+    );
+  }
+}

--- a/lib/presentation/component/map_bottom_sheet.dart
+++ b/lib/presentation/component/map_bottom_sheet.dart
@@ -9,7 +9,7 @@ import 'package:photopin/presentation/component/base_icon_button.dart';
 /// showModalBottomSheet() 함수를 사용하여 띄울 수 있는 모달 바텀 시트입니다.
 /// 기본적으로 showModalBottomSheet의 isDismissible 속성을 반드시 false로 설정해야 [onClosing]과 [onTapClose] 호출이 보장됩니다.
 /// [onClosing] 인자는 바텀 시트가 닫히기 전, 어떤 동작을 해야할 때 사용되며 [onTapClose] 인자는 [onClosing]이 호출된 후에 실행됩니다.
-class MapBottomSheet extends StatelessWidget {
+class MapBottomSheet extends StatefulWidget {
   final String title;
   final String imageUrl;
   final DateTime dateTime;
@@ -34,8 +34,19 @@ class MapBottomSheet extends StatelessWidget {
     this.onClosing,
   });
 
+  @override
+  State<MapBottomSheet> createState() => _MapBottomSheetState();
+}
+
+class _MapBottomSheetState extends State<MapBottomSheet> {
   String _formattedDateTime() =>
-      '${dateTime.formDateString()}, ${dateTime.year} • ${dateTime.hour}:${dateTime.minute} ${dateTime.formMeridiem()}';
+      '${widget.dateTime.formDateString()}, ${widget.dateTime.year} • ${widget.dateTime.hour}:${widget.dateTime.minute} ${widget.dateTime.formMeridiem()}';
+
+  @override
+  void dispose() {
+    widget.onClosing?.call();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -57,7 +68,7 @@ class MapBottomSheet extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
                   Text(
-                    title,
+                    widget.title,
                     style: AppFonts.mediumTextBold.copyWith(
                       color: AppColors.textColor,
                     ),
@@ -65,8 +76,7 @@ class MapBottomSheet extends StatelessWidget {
                   const Spacer(),
                   GestureDetector(
                     onTap: () {
-                      onClosing?.call();
-                      onTapClose();
+                      widget.onTapClose();
                     },
                     child: Icon(Icons.close, size: 20, color: AppColors.gray2),
                   ),
@@ -79,7 +89,7 @@ class MapBottomSheet extends StatelessWidget {
                   decoration: BoxDecoration(
                     borderRadius: BorderRadius.circular(10),
                     image: DecorationImage(
-                      image: NetworkImage(imageUrl),
+                      image: NetworkImage(widget.imageUrl),
                       fit: BoxFit.cover,
                     ),
                   ),
@@ -110,7 +120,7 @@ class MapBottomSheet extends StatelessWidget {
                         size: 16,
                         iconData: Icons.location_on,
                       ),
-                      Text(location, style: AppFonts.smallTextRegular),
+                      Text(widget.location, style: AppFonts.smallTextRegular),
                     ],
                   ),
                   Row(
@@ -123,7 +133,7 @@ class MapBottomSheet extends StatelessWidget {
                       const SizedBox(width: 12),
                       Expanded(
                         child: Text(
-                          comment,
+                          widget.comment,
                           softWrap: true,
                           style: AppFonts.smallTextRegular,
                         ),
@@ -141,7 +151,7 @@ class MapBottomSheet extends StatelessWidget {
                       buttonColor: AppColors.primary100,
                       iconName: Icons.edit,
                       buttonName: 'Edit',
-                      onClick: onTapEdit,
+                      onClick: widget.onTapEdit,
                     ),
                   ),
                   Expanded(
@@ -150,7 +160,7 @@ class MapBottomSheet extends StatelessWidget {
                       buttonColor: AppColors.secondary100,
                       iconName: Icons.share,
                       buttonName: 'Share',
-                      onClick: onTapShare,
+                      onClick: widget.onTapShare,
                     ),
                   ),
                 ],

--- a/test/presentation/component/map_bottom_sheet_test.dart
+++ b/test/presentation/component/map_bottom_sheet_test.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:network_image_mock/network_image_mock.dart';
+import 'package:photopin/presentation/component/map_bottom_sheet.dart';
+
+void main() {
+  const String title = 'Seoul';
+  const String imageUrl = '';
+  const String location = 'Gangnam';
+  const String comment = '서울 최고';
+  final DateTime dateTime = DateTime.parse('2025-05-01 16:00:00');
+
+  testWidgets('버튼 클릭 시 MapBottomSheet가 열리고 구성 요소가 정상적으로 보여야한다.', (
+    WidgetTester tester,
+  ) async {
+    await mockNetworkImagesFor(() async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SafeArea(
+              child: Builder(
+                builder: (context) {
+                  return Center(
+                    child: ElevatedButton(
+                      onPressed: () {
+                        showModalBottomSheet(
+                          context: context,
+                          isScrollControlled: true,
+                          builder: (BuildContext context) {
+                            return MapBottomSheet(
+                              title: title,
+                              location: location,
+                              imageUrl: imageUrl,
+                              comment: comment,
+                              dateTime: dateTime,
+                              onTapEdit: () {},
+                              onTapShare: () {},
+                              onTapClose: () {
+                                Navigator.pop(context);
+                              },
+                            );
+                          },
+                        );
+                      },
+                      child: const Text('Show BottomSheet'),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Show BottomSheet'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(MapBottomSheet), findsOneWidget);
+      expect(find.text('Seoul'), findsOneWidget);
+      expect(find.text('Gangnam'), findsOneWidget);
+      expect(find.text('서울 최고'), findsOneWidget);
+      expect(find.byIcon(Icons.calendar_month), findsOneWidget);
+      expect(find.byIcon(Icons.location_on), findsOneWidget);
+      expect(find.byIcon(Icons.comment), findsOneWidget);
+      expect(find.byIcon(Icons.edit), findsOneWidget);
+      expect(find.byIcon(Icons.share), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(MapBottomSheet), findsNothing);
+    });
+  });
+
+  testWidgets(
+    'MapBottomSheet의 닫기 아이콘을 탭하면 MapBottomSheet가 정상적으로 닫히면서 콜백이 호출되어야 한다.',
+
+    (WidgetTester tester) async {
+      bool isClosing = false;
+      bool isTapped = false;
+
+      await mockNetworkImagesFor(() async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SafeArea(
+                child: Builder(
+                  builder: (context) {
+                    return Center(
+                      child: ElevatedButton(
+                        onPressed: () {
+                          showModalBottomSheet(
+                            context: context,
+                            isScrollControlled: true,
+                            builder: (BuildContext context) {
+                              return MapBottomSheet(
+                                title: title,
+                                location: location,
+                                imageUrl: imageUrl,
+                                comment: comment,
+                                dateTime: dateTime,
+                                onTapEdit: () {},
+                                onTapShare: () {},
+                                onTapClose: () {
+                                  isTapped = true;
+                                  Navigator.pop(context);
+                                },
+                                onClosing: () {
+                                  isClosing = true;
+                                },
+                              );
+                            },
+                          );
+                        },
+                        child: const Text('Show BottomSheet'),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Show BottomSheet'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byIcon(Icons.close));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(MapBottomSheet), findsNothing);
+        expect(isClosing, true);
+        expect(isTapped, true);
+      });
+    },
+  );
+
+  testWidgets(
+    'MapBottomSheet의 Edit, Share 버튼을 탭하면 onTapEdit, onTapShare 콜백 함수가 실행되어야 한다.',
+    (WidgetTester tester) async {
+      bool isTapEdit = false;
+      bool isTapShare = false;
+
+      await mockNetworkImagesFor(() async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SafeArea(
+                child: Builder(
+                  builder: (context) {
+                    return Center(
+                      child: ElevatedButton(
+                        onPressed: () {
+                          showModalBottomSheet(
+                            context: context,
+                            isScrollControlled: true,
+                            builder: (BuildContext context) {
+                              return MapBottomSheet(
+                                title: title,
+                                location: location,
+                                imageUrl: imageUrl,
+                                comment: comment,
+                                dateTime: dateTime,
+                                onTapEdit: () {
+                                  isTapEdit = true;
+                                },
+                                onTapShare: () {
+                                  isTapShare = true;
+                                },
+                                onTapClose: () {},
+                              );
+                            },
+                          );
+                        },
+                        child: const Text('Show BottomSheet'),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Show BottomSheet'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Edit'));
+        await tester.tap(find.text('Share'));
+
+        expect(isTapShare, true);
+        expect(isTapEdit, true);
+      });
+    },
+  );
+}


### PR DESCRIPTION
## 🔍 개요 (Summary)

- map_bottom_sheet 컴포넌트 구현
- 컴포넌트 위젯 테스트 코드 작성
- datetime extension에 `formMeridiem` 함수 추가
---

## ✅ 변경 사항 (Changes)

- datetime extension에 `formMeridiem` 함수 추가
- DateTime 객체의 hour 속성을 기준으로 12시가 넘으면 PM, 그 외의 경우 AM 문자열 반환

---

## 📸 스크린샷 (Screenshots, 선택사항)

<img width="357" alt="image" src="https://github.com/user-attachments/assets/87c87ec7-7cf7-4f7e-b0bc-3c8b77268aff" />

---

## 🔗 관련 이슈 (Related Issues)

Closes #39 

---

## 🧪 테스트 (Test)

<img width="919" alt="image" src="https://github.com/user-attachments/assets/c8024789-1ecf-4a60-83f7-d2ca41b35b80" />

- `MapBottomSheet` 위젯 테스트 수행
- 위젯이 정상적으로 렌더링 되고, UI 구성 요소가 모두 의도한대로 렌더링 되었는지 테스트 작성
- `onTapClose`, `onTapEdit`, `onTapShare`, `onClosing` 콜백 함수 테스트 작성

## 📝 참고 사항 (Notes)

- showModalBottomSheet() 함수를 통해 해당 바텀 시트를 사용함
  - showModalBottomSheet의 isDismissible 속성을 반드시 false로 설정해야 [onClosing]과 [onTapClose] 호출이 보장됩니다.
- 가로 사진일 경우 안짤리는데 세로 사진일 경우 비율에 의해 아래쪽이 잘리게 됨
  - 방법 1: 사진이 보여지게 되는 포지션 변경 (이 방법은 무리인거 같음, 사진마다 주요 피사체? 위치가 다르고, 동적으로 파악하기 불가능함)
  - 방법 2: 사진 비율이  1대1로 보여지게 (이렇게 할 경우 사진이 세로로 길어지게 됨)
  - 일단 추후에 카메라 기능 구현되면 찍어보고 결정
 
---
## 👀 리뷰어 체크리스트 (For Reviewer)

- [ ] UI가 디자인과 일치하는지 확인
- [ ] 불필요한 코드/주석이 없는지 확인
- [ ] 테스트가 적절히 작성되었는지 확인