### PR TITLE
#46 notification card 컴포넌트

### DIFF
--- a/lib/core/extensions/datetime_extension.dart
+++ b/lib/core/extensions/datetime_extension.dart
@@ -59,4 +59,34 @@ extension DatetimeExtension on DateTime {
   String formMeridiem() {
     return hour >= 12 ? 'PM' : 'AM';
   }
+
+  /// DateTime 인스턴스를 현재 시간과 비교하여 다음과 같은 형식의 문자열로 반환합니다.
+  /// - 'just now' : 현재 시간과 1분 이내의 차이
+  /// - 'X minutes ago' : 현재 시간과 1시간 이내의 차이
+  /// - 'X hours ago' : 현재 시간과 1일 이내의 차이
+  /// - 'X days ago' : 현재 시간과 1달 이내의 차이
+  /// - 'X months ago' : 현재 시간과 1년 이내의 차이
+  /// - 'X years ago' : 현재 시간과 1년 이상의 차이
+  String timeAgoFromNow() {
+    final now = DateTime.now();
+
+    if (isAfter(now)) {
+      throw ArgumentError('미래 시간은 허용되지 않습니다.');
+    }
+
+    final Duration diff = now.difference(this);
+
+    final int days = diff.inDays;
+    final int hours = diff.inHours;
+    final int minutes = diff.inMinutes;
+
+    if (days >= 365) return '${days ~/ 365} years ago';
+    if (days >= 30) return '${days ~/ 30} months ago';
+    if (days >= 7) return '${days ~/ 7} weeks ago';
+    if (days >= 1) return '$days days ago';
+    if (hours >= 1) return '$hours hours ago';
+    if (minutes >= 1) return '$minutes minutes ago';
+
+    return 'just now';
+  }
 }

--- a/lib/core/styles/app_color.dart
+++ b/lib/core/styles/app_color.dart
@@ -7,6 +7,7 @@ abstract class AppColors {
   static const Color gray2 = Color(0xFF797979);
   static const Color gray3 = Color(0xFFA9A9A9);
   static const Color gray4 = Color(0xFFD9D9D9);
+  static const Color gray5 = Color(0xFFF3F4F6);
   static const Color white = Color(0xFFFFFFFF);
 
   // Primary Colors

--- a/lib/presentation/component/notification_card.dart
+++ b/lib/presentation/component/notification_card.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:photopin/core/extensions/datetime_extension.dart';
+import 'package:photopin/core/styles/app_color.dart';
+import 'package:photopin/core/styles/app_font.dart';
+import 'package:photopin/presentation/component/base_icon.dart';
+
+class NotificationCard extends StatelessWidget {
+  final String title;
+  final String message;
+  final DateTime dateTime;
+  final String badgeTitle;
+  final IconData iconData;
+  final VoidCallback onTapDetail;
+  final bool isRead;
+
+  const NotificationCard({
+    super.key,
+    required this.title,
+    required this.message,
+    required this.dateTime,
+    required this.badgeTitle,
+    required this.onTapDetail,
+    this.iconData = Icons.visibility,
+    this.isRead = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.all(12),
+      height: 118,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        color: AppColors.white,
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          BaseIcon(
+            iconColor: AppColors.primary100,
+            iconData: iconData,
+            size: 18,
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Text(
+                      title,
+                      style: AppFonts.smallTextBold.copyWith(
+                        color: AppColors.black,
+                      ),
+                    ),
+                    const Spacer(),
+                    Text(
+                      dateTime.timeAgoFromNow(),
+                      style: AppFonts.smallerTextRegular.copyWith(
+                        color: AppColors.gray2,
+                      ),
+                    ),
+                  ],
+                ),
+                Text(
+                  message,
+                  style: AppFonts.smallerTextRegular.copyWith(
+                    color: AppColors.black,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    _NotificationBadge(title: badgeTitle),
+                    GestureDetector(
+                      onTap: onTapDetail,
+                      child: Text(
+                        'View Details',
+                        style: AppFonts.smallTextRegular.copyWith(
+                          color: AppColors.primary100,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          Column(
+            children: [
+              const SizedBox(height: 5.85),
+              Container(
+                key: Key('read_checker'),
+                height: 8,
+                width: 8,
+                decoration: BoxDecoration(
+                  color: isRead ? AppColors.white : AppColors.primary100,
+                  shape: BoxShape.circle,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NotificationBadge extends StatelessWidget {
+  final String title;
+
+  const _NotificationBadge({required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(8),
+        color: AppColors.gray5,
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        spacing: 2,
+        children: [
+          Icon(Icons.link, size: 18, color: AppColors.gray1),
+          Text(
+            title,
+            style: AppFonts.smallerTextRegular.copyWith(color: AppColors.gray1),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/presentation/component/notification_card_test.dart
+++ b/test/presentation/component/notification_card_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:photopin/core/extensions/datetime_extension.dart';
+import 'package:photopin/core/styles/app_color.dart';
+import 'package:photopin/presentation/component/notification_card.dart';
+
+void main() {
+  final String title = 'Title';
+  final String message = 'Message';
+  final String badgeTitle = 'Badge Title';
+  final DateTime dateTime = DateTime.parse('2025-05-02 16:00:00');
+
+  testWidgets('NotificationCard가 정상적으로 렌더링 되고, 구성요소가 올바르게 표시되어야한다.', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: NotificationCard(
+              title: title,
+              dateTime: dateTime,
+              message: message,
+              badgeTitle: badgeTitle,
+              onTapDetail: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text(title), findsOneWidget);
+    expect(find.text(message), findsOneWidget);
+    expect(find.text(badgeTitle), findsOneWidget);
+    expect(find.text(dateTime.timeAgoFromNow()), findsOneWidget);
+    expect(find.byIcon(Icons.visibility), findsOneWidget);
+    expect(find.byIcon(Icons.link), findsOneWidget);
+  });
+
+  testWidgets(
+    'NotificationCard의 isRead 속성이 true일 경우, 우측 상단의 read checker 표시가 하얀색으로 렌더링 되야한다.',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: NotificationCard(
+                title: title,
+                dateTime: dateTime,
+                message: message,
+                badgeTitle: badgeTitle,
+                onTapDetail: () {},
+                isRead: true,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      Finder readChecker = find.byKey(Key('read_checker'));
+      Container readContainer = tester.firstWidget(readChecker) as Container;
+      BoxDecoration decoration = readContainer.decoration as BoxDecoration;
+
+      expect(decoration.color, AppColors.white);
+    },
+  );
+
+  testWidgets(
+    'NotificationCard의 View Detail을 누를 경우 onTapDetail 콜백 함수가 실행되어야한다.',
+    (tester) async {
+      bool onTapped = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: NotificationCard(
+                title: title,
+                dateTime: dateTime,
+                message: message,
+                badgeTitle: badgeTitle,
+                onTapDetail: () {
+                  onTapped = true;
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('View Details'));
+      expect(onTapped, true);
+    },
+  );
+}


### PR DESCRIPTION
## 🔍 개요 (Summary)

- NotificationCard 컴포넌트 구현
- 위젯 테스트 코드 작성
- DateTime Extension에 `timeAgoFromNow()`가 추가됨

---

## ✅ 변경 사항 (Changes)

- DateTime Extension에 `timeAgoFromNow()`가 추가됨
  - DateTime 객체를 현재 시간으로 비교하여 몇 분 전, 몇 시간 전, 몇 일 전 등의 영문으로 반환하는 함수

---

## 📸 스크린샷 (Screenshots, 선택사항)

<img width="411" alt="image" src="https://github.com/user-attachments/assets/78a37614-15bd-431b-8b06-4b1e3df85f9d" />

---

## 🔗 관련 이슈 (Related Issues)

Closes #46 

---

## 🧪 테스트 (Test)

- NotificationCard의 정상 렌더링, 특히 구성요소들이 올바르게 표시 되는지 테스트
- NotificationCard의 속성 isRead를 true일 경우 readChecker(읽음 표시)가 표시되지 않아야 하는 시나리오 테스트
- NotificationCard의 View Details를 누를 경우 콜백 함수 작동 테스트

## 👀 리뷰어 체크리스트 (For Reviewer)

- [ ] 기능이 명세에 맞게 동작하는지 확인
- [ ] 불필요한 코드/주석이 없는지 확인
- [ ] 테스트가 적절히 작성되었는지 확인