### PR TITLE
#42 feat recent activity tile

### DIFF
--- a/lib/core/extensions/datetime_extension.dart
+++ b/lib/core/extensions/datetime_extension.dart
@@ -91,13 +91,36 @@ extension DatetimeExtension on DateTime {
     final int hours = diff.inHours;
     final int minutes = diff.inMinutes;
 
-    if (days >= 365) return '${days ~/ 365} years ago';
-    if (days >= 30) return '${days ~/ 30} months ago';
-    if (days >= 7) return '${days ~/ 7} weeks ago';
-    if (days >= 1) return '$days days ago';
-    if (hours >= 1) return '$hours hours ago';
-    if (minutes >= 1) return '$minutes minutes ago';
-
+    if (days >= 365) {
+      final value = days ~/ 365;
+      final unit  = value == 1 ? 'year'  : 'years';
+      return '$value $unit ago';
+    }
+    if (days >= 30) {
+      final value = days ~/ 30;
+      final unit  = value == 1 ? 'month' : 'months';
+      return '$value $unit ago';
+    }
+    if (days >= 7) {
+      final value = days ~/ 7;
+      final unit  = value == 1 ? 'week'  : 'weeks';
+      return '$value $unit ago';
+    }
+    if (days >= 1) {
+      final value = days;
+      final unit  = value == 1 ? 'day'   : 'days';
+      return '$value $unit ago';
+    }
+    if (hours >= 1) {
+      final value = hours;
+      final unit  = value == 1 ? 'hour'  : 'hours';
+      return '$value $unit ago';
+    }
+    if (minutes >= 1) {
+      final value = minutes;
+      final unit  = value == 1 ? 'minute': 'minutes';
+      return '$value $unit ago';
+    }
     return 'just now';
   }
 }

--- a/lib/presentation/component/recent_activity_tile.dart
+++ b/lib/presentation/component/recent_activity_tile.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:photopin/core/styles/app_color.dart';
+import 'package:photopin/presentation/component/base_icon.dart';
+import 'package:photopin/core/extensions/datetime_extension.dart';
+import '../../core/styles/app_font.dart';
+
+class RecentActivityTile extends StatelessWidget {
+  final String title;
+  final DateTime dateTime;
+  final VoidCallback onTap;
+
+  const RecentActivityTile({
+    super.key,
+    required this.title,
+    required this.dateTime,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        width: double.infinity,
+        height: 64,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          color: AppColors.white,
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Container(
+              width: 40,
+              height: 40,
+              decoration: BoxDecoration(
+                color: AppColors.primary40,
+                shape: BoxShape.circle,
+              ),
+              child: BaseIcon(
+                iconColor: AppColors.primary100,
+                iconData: Icons.link,
+                size: 18,
+              ),
+            ),
+            SizedBox(width: 12),
+            Container(
+              height: 40,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Link shared: $title',
+                    style: AppFonts.smallTextBold.copyWith(
+                      color: AppColors.black,
+                    ),
+                  ),
+                  Text(
+                    dateTime.timeAgoFromNow(),
+                    style: AppFonts.smallerTextRegular.copyWith(
+                      color: AppColors.gray2,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/component/recent_activity_tile.dart
+++ b/lib/presentation/component/recent_activity_tile.dart
@@ -7,6 +7,7 @@ import '../../core/styles/app_font.dart';
 class RecentActivityTile extends StatelessWidget {
   final String title;
   final DateTime dateTime;
+  final IconData iconData;
   final VoidCallback onTap;
 
   const RecentActivityTile({
@@ -14,6 +15,7 @@ class RecentActivityTile extends StatelessWidget {
     required this.title,
     required this.dateTime,
     required this.onTap,
+    required this.iconData,
   });
 
   @override
@@ -40,7 +42,7 @@ class RecentActivityTile extends StatelessWidget {
               ),
               child: BaseIcon(
                 iconColor: AppColors.primary100,
-                iconData: Icons.link,
+                iconData: iconData,
                 size: 18,
               ),
             ),
@@ -51,7 +53,7 @@ class RecentActivityTile extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    'Link shared: $title',
+                    title,
                     style: AppFonts.smallTextBold.copyWith(
                       color: AppColors.black,
                     ),

--- a/test/presentation/component/recent_activity_tile_test.dart
+++ b/test/presentation/component/recent_activity_tile_test.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_test/flutter_test.dart';
+
+
+void main() {
+  testWidgets('', (WidgetTester tester) async {
+
+  });
+}

--- a/test/presentation/component/recent_activity_tile_test.dart
+++ b/test/presentation/component/recent_activity_tile_test.dart
@@ -1,8 +1,57 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
+import 'package:photopin/presentation/component/recent_activity_tile.dart';
 
 void main() {
-  testWidgets('', (WidgetTester tester) async {
+  group('RecentActivityTile 테스트', () {
+    testWidgets(
+      'RecentActivityTile 컴포넌트를 클릭하여 onTap함수가 반응하는 확인하기 위하여 변수 count가 0에서 1이 되게 바꾼다.',
+      (WidgetTester tester) async {
+        int count = 0;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RecentActivityTile(
+                title: 'Seoul',
+                dateTime: DateTime.now(),
+                onTap: () {
+                  count++;
+                },
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
 
+        expect(count, 0);
+
+        await tester.tap(find.byType(RecentActivityTile));
+        await tester.pump();
+
+        expect(count, 1);
+      },
+    );
+    testWidgets(
+      '현재 시간을 기준으로  31일 전과 비교하여 dateTime 인스턴스 변수가 "1 months ago"가 되는지 확인한다',
+      (WidgetTester tester) async {
+        final now = DateTime.now();
+        final oneMonthAgo = now.subtract(Duration(days: 31));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RecentActivityTile(
+                title: 'Seoul',
+                dateTime: oneMonthAgo,
+                onTap: () {},
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('1 months ago'), findsOneWidget);
+      },
+    );
   });
 }

--- a/test/presentation/component/recent_activity_tile_test.dart
+++ b/test/presentation/component/recent_activity_tile_test.dart
@@ -32,7 +32,7 @@ void main() {
       },
     );
     testWidgets(
-      '현재 시간을 기준으로  31일 전과 비교하여 dateTime 인스턴스 변수가 "1 months ago"가 되는지 확인한다',
+      '현재 시간을 기준으로  31일 전과 비교하여 dateTime 인스턴스 변수가 "1 month ago"가 되는지 확인한다',
       (WidgetTester tester) async {
         final now = DateTime.now();
         final oneMonthAgo = now.subtract(Duration(days: 31));
@@ -50,7 +50,7 @@ void main() {
         );
         await tester.pump();
 
-        expect(find.text('1 months ago'), findsOneWidget);
+        expect(find.text('1 month ago'), findsOneWidget);
       },
     );
   });

--- a/test/presentation/component/recent_activity_tile_test.dart
+++ b/test/presentation/component/recent_activity_tile_test.dart
@@ -5,7 +5,7 @@ import 'package:photopin/presentation/component/recent_activity_tile.dart';
 void main() {
   group('RecentActivityTile 테스트', () {
     testWidgets(
-      'RecentActivityTile 컴포넌트를 클릭하여 onTap함수가 반응하는 확인하기 위하여 변수 count가 0에서 1이 되게 바꾼다.',
+      'RecentActivityTile 컴포넌트를 클릭하여 onTap함수가 실행되는지 확인하기 위하여 변수 count가 0에서 1이 되게 바꾼다.',
       (WidgetTester tester) async {
         int count = 0;
         await tester.pumpWidget(
@@ -14,6 +14,7 @@ void main() {
               body: RecentActivityTile(
                 title: 'Seoul',
                 dateTime: DateTime.now(),
+                iconData: Icons.link,
                 onTap: () {
                   count++;
                 },
@@ -32,10 +33,10 @@ void main() {
       },
     );
     testWidgets(
-      '현재 시간을 기준으로  31일 전과 비교하여 dateTime 인스턴스 변수가 "1 month ago"가 되는지 확인한다',
+      '현재 시간을 기준으로  30일 전과 비교하여 dateTime 인스턴스 변수가 "1 month ago"가 되는지 확인한다',
       (WidgetTester tester) async {
         final now = DateTime.now();
-        final oneMonthAgo = now.subtract(Duration(days: 31));
+        final oneMonthAgo = now.subtract(Duration(days: 30));
 
         await tester.pumpWidget(
           MaterialApp(
@@ -44,6 +45,7 @@ void main() {
                 title: 'Seoul',
                 dateTime: oneMonthAgo,
                 onTap: () {},
+                iconData: Icons.link,
               ),
             ),
           ),


### PR DESCRIPTION
## 🔍 개요 (Summary)

- RecentActivityTile 코드 생성
- RecentActivityTile test 생성 (onTap 확인,  extension timeAgoFromNow 확인)

---


## 📸 스크린샷 (Screenshots, 선택사항)

![image](https://github.com/user-attachments/assets/efed04f4-e6bc-4a6d-bc5f-82d16385edf7)

---

## 🔗 관련 이슈 (Related Issues)

#42 

---

## 🧪 테스트 (Test)

- RecentActivityTile 전체 컴포넌트가 클릭되어 onTap 콜백함수가 반응하는지 확인
- RecentActivityTile 인스턴스 변수 dateTime이 extension timeAgoFromNow를 사용하여  잘 변형되는지 확인


---

## 👀 리뷰어 체크리스트 (For Reviewer)

- [ ] 기능이 명세에 맞게 동작하는지 확인
- [ ] 불필요한 코드/주석이 없는지 확인
- [ ] 테스트가 적절히 작성되었는지 확인
