### PR TITLE
#75 feat timeline tile

### DIFF
--- a/lib/core/enums/timeline_divide.dart
+++ b/lib/core/enums/timeline_divide.dart
@@ -1,0 +1,1 @@
+enum TimelineDivide { morning, day, night, dawn, unknown }

--- a/lib/core/extensions/datetime_extension.dart
+++ b/lib/core/extensions/datetime_extension.dart
@@ -1,3 +1,5 @@
+import 'package:photopin/core/enums/timeline_divide.dart';
+
 extension DatetimeExtension on DateTime {
   String _monthName(int m) {
     const full = [
@@ -69,6 +71,29 @@ extension DatetimeExtension on DateTime {
 
   String formMeridiem() {
     return hour >= 12 ? 'PM' : 'AM';
+  }
+
+  String formOnlyTime() {
+    // 시간 (12시간제)
+    int hour12 = hour % 12;
+    if (hour12 == 0) hour12 = 12; // 0시는 12시로 표시
+
+    // 분 (항상 2자리로)
+    final minute = this.minute.toString().padLeft(2, '0');
+    return '$hour12:$minute ${formMeridiem()}';
+  }
+
+  TimelineDivide formQuaterDivide() {
+    if (6 <= hour && hour <= 12) {
+      return TimelineDivide.morning;
+    } else if (12 < hour && hour <= 18) {
+      return TimelineDivide.day;
+    } else if (18 < hour && hour <= 23) {
+      return TimelineDivide.night;
+    } else if (0 <= hour && hour < 6) {
+      return TimelineDivide.dawn;
+    }
+    return TimelineDivide.unknown;
   }
 
   /// DateTime 인스턴스를 현재 시간과 비교하여 다음과 같은 형식의 문자열로 반환합니다.

--- a/lib/presentation/component/timeline_tile.dart
+++ b/lib/presentation/component/timeline_tile.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:photopin/core/enums/timeline_divide.dart';
+import 'package:photopin/core/extensions/datetime_extension.dart';
+import 'package:photopin/core/styles/app_color.dart';
+import 'package:photopin/core/styles/app_font.dart';
+
+class TimeLineTile extends StatelessWidget {
+  final DateTime dateTime;
+  final String title;
+  final String imageUrl;
+  const TimeLineTile({
+    super.key,
+    required this.dateTime,
+    required this.title,
+    required this.imageUrl,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 64,
+      padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 12),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(8),
+        color: AppColors.white,
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 8,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(999),
+              color: switch (dateTime.formQuaterDivide()) {
+                TimelineDivide.morning => AppColors.secondary80,
+                TimelineDivide.day => AppColors.marker50,
+                TimelineDivide.night => AppColors.marker40,
+                TimelineDivide.dawn => AppColors.marker80,
+                TimelineDivide.unknown => AppColors.primary60,
+              },
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(title, style: AppFonts.smallTextRegular),
+                Text(
+                  'Visited at ${dateTime.formOnlyTime()}',
+                  style: AppFonts.smallerTextRegular.copyWith(
+                    color: AppColors.gray3,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          AspectRatio(
+            aspectRatio: 1 / 1,
+            child: Container(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12),
+                image: DecorationImage(
+                  image: NetworkImage(imageUrl),
+                  fit: BoxFit.cover,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/component/timeline_tile.dart
+++ b/lib/presentation/component/timeline_tile.dart
@@ -42,6 +42,7 @@ class TimeLineTile extends StatelessWidget {
           const SizedBox(width: 12),
           Expanded(
             child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(title, style: AppFonts.smallTextRegular),

--- a/test/presentation/component/timeline_tile_test.dart
+++ b/test/presentation/component/timeline_tile_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:network_image_mock/network_image_mock.dart';
+import 'package:photopin/core/enums/timeline_divide.dart';
+import 'package:photopin/core/styles/app_color.dart';
+import 'package:photopin/presentation/component/timeline_tile.dart';
+
+void main() {
+  group('timeline tile component 테스트 : ', () {
+    final Color morningColor = AppColors.secondary80;
+    final Color dayColor = AppColors.marker50;
+    final Color nightColor = AppColors.marker40;
+    final Color dawnColor = AppColors.marker80;
+
+    testWidgets('제대로 생성되어야 한다.', (tester) async {
+      await mockNetworkImagesFor(
+        () async => await tester.pumpWidget(
+          MaterialApp(
+            home: TimeLineTile(
+              dateTime: DateTime(1999, 11, 30, 7, 30),
+              title: 'Cafe Bene',
+              imageUrl: '',
+            ),
+          ),
+        ),
+      );
+
+      final Finder finder = find.text('Cafe Bene');
+
+      expect(finder, findsOneWidget);
+    });
+    testWidgets('TimeLineTile 시간대별 색상 테스트\n'
+        '- 06:00 ~ 12:00 일 경우 AppColors.secondary80 이어야한다.\n'
+        '- 12:00 ~ 18:00 일 경우 AppColors.marker50 이어야한다.\n'
+        '- 18:00 ~ 23:00 일 경우 AppColors.marker40 이어야한다.\n'
+        '- 00:00 ~ 06:00 일 경우 AppColors.marker80 이어야한다.', (
+      WidgetTester tester,
+    ) async {
+      // 여러 시간대 테스트 케이스
+      final testCases = [
+        {
+          'time': DateTime(2023, 5, 7, 9, 30), // 오전
+          'expectedColor': morningColor,
+          'divideType': TimelineDivide.morning,
+        },
+        {
+          'time': DateTime(2023, 5, 7, 14, 30), // 오후
+          'expectedColor': dayColor,
+          'divideType': TimelineDivide.day,
+        },
+        {
+          'time': DateTime(2023, 5, 7, 19, 30), // 저녁
+          'expectedColor': nightColor,
+          'divideType': TimelineDivide.day,
+        },
+        {
+          'time': DateTime(2023, 5, 7, 01, 30), // 새벽
+          'expectedColor': dawnColor,
+          'divideType': TimelineDivide.day,
+        },
+      ];
+
+      for (final testCase in testCases) {
+        // 위젯 다시 빌드
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: TimeLineTile(
+                dateTime: testCase['time'] as DateTime,
+                title: '테스트',
+                imageUrl: '',
+              ),
+            ),
+          ),
+        );
+
+        // 색상 막대 Container 찾기
+        final colorBarFinder = find.descendant(
+          of: find.byType(Row),
+          matching: find.byWidgetPredicate(
+            (widget) =>
+                widget is Container && widget.constraints?.maxWidth == 8,
+          ),
+        );
+
+        final Container colorBarContainer = tester.widget<Container>(
+          colorBarFinder,
+        );
+        final BoxDecoration decoration =
+            colorBarContainer.decoration as BoxDecoration;
+
+        // 시간대에 따른 색상 확인
+        expect(decoration.color, testCase['expectedColor']);
+
+        // 다음 테스트를 위해 현재 위젯 정리
+        await tester.pumpAndSettle();
+      }
+    });
+  });
+}


### PR DESCRIPTION
## 🔍 개요 (Summary)

- timeline tile component 생성
- datetime extension 함수 추가
- timeline divide enum 생성

---

## ✅ 변경 사항 (Changes)

- timeline divide enum 생성
    - 시간 별로 morning, day, night, dawn 구분 위해 생성
- datetiem extension 함수 추가
    - formQuaterDived() : 시간대별로 4등분 후 enum 으로 반환
    - fromOnlyTime() : 받은 DateTime 의 시간을 12시간제로 변경 후 AM, PM 추가해서 반환
- timeline component 생성

---

## 📸 스크린샷 (Screenshots, 선택사항)

![image](https://github.com/user-attachments/assets/fc891f8e-8a91-4925-916b-90be7335af71)

---

## 🔗 관련 이슈 (Related Issues)


#75 


---

## 🧪 테스트 (Test)

- [x] 제대로 생성되어야한다.
- [x] 06:00 ~ 12:00 일 경우 AppColors.secondary80 이어야한다.
- [x] 12:00 ~ 18:00 일 경우 AppColors.marker50 이어야한다.
- [x] 18:00 ~ 23:00 일 경우 AppColors.marker40 이어야한다.
- [x] 00:00 ~ 06:00 일 경우 AppColors.marker80 이어야한다.

## 📝 참고 사항 (Notes)

- 리뷰어가 이해하는 데 도움이 될 만한 기타 정보
- 논의가 필요한 부분이나 리뷰 요청 포인트 등

---

## 👀 리뷰어 체크리스트 (For Reviewer)

- [ ] 기능이 명세에 맞게 동작하는지 확인
- [ ] 불필요한 코드/주석이 없는지 확인
- [ ] 테스트가 적절히 작성되었는지 확인
