### PR TITLE
#77 feat search bar

### DIFF
--- a/lib/presentation/component/search_bar.dart
+++ b/lib/presentation/component/search_bar.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:photopin/core/styles/app_color.dart';
+
+/// SearchBarWidget은 앱에서 검색 기능을 위한 검색창 UI를 제공합니다.
+/// [placeholder]를 통해 힌트 텍스트를 설정할 수 있으며,
+/// [onChanged] 콜백을 통해 텍스트 변경 이벤트를 처리할 수 있습니다.
+class SearchBarWidget extends StatelessWidget {
+  final String placeholder;
+  final ValueChanged<String>? onChanged;
+
+  const SearchBarWidget({super.key, required this.placeholder, this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: 46,
+      child: TextField(
+        onChanged: onChanged,
+        decoration: InputDecoration(
+          hintText: placeholder,
+          suffixIcon: Container(
+            width: 20,
+            height: 20,
+            margin: const EdgeInsets.all(10),
+            decoration: BoxDecoration(
+              color: AppColors.gray4,
+              borderRadius: BorderRadius.circular(100),
+            ),
+            child: const Icon(Icons.search, size: 16),
+          ),
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(8),
+            borderSide: const BorderSide(color: Colors.grey),
+          ),
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: 8,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/presentation/component/search_bar_test.dart
+++ b/test/presentation/component/search_bar_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:photopin/presentation/component/search_bar.dart'; 
+
+void main() {
+  group('SearchBarWidget 테스트', () {
+    testWidgets('SearchBarWidget이 정상적으로 렌더링되는지 테스트합니다.', (
+      WidgetTester tester,
+    ) async {
+      // 테스트할 위젯 생성
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: SearchBarWidget(placeholder: 'Search')),
+        ),
+      );
+
+      // TextField 위젯이 존재하는지 확인
+      expect(find.byType(TextField), findsOneWidget);
+
+      // placeholder 텍스트가 올바르게 표시되는지 확인
+      expect(find.text('Search'), findsOneWidget);
+
+      // 검색 아이콘이 표시되는지 확인
+      expect(find.byIcon(Icons.search), findsOneWidget);
+    });
+
+    testWidgets('검색 입력 시 onChanged 콜백이 호출되는지 테스트합니다.', (
+      WidgetTester tester,
+    ) async {
+      String searchText = '';
+
+      // 테스트할 위젯 생성 (onChanged 콜백 포함)
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SearchBarWidget(
+              placeholder: 'Search',
+              onChanged: (value) {
+                searchText = value;
+              },
+            ),
+          ),
+        ),
+      );
+
+      // TextField 찾기
+      final textField = find.byType(TextField);
+
+      // 텍스트 입력
+      await tester.enterText(textField, '테스트 검색어');
+
+      // onChanged 콜백이 호출되어 searchText 변수가 업데이트되었는지 확인
+      expect(searchText, '테스트 검색어');
+    });
+  });
+}

--- a/test/presentation/component/search_bar_test.dart
+++ b/test/presentation/component/search_bar_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:photopin/presentation/component/search_bar.dart'; 
+import 'package:photopin/presentation/component/search_bar.dart';
 
 void main() {
   group('SearchBarWidget 테스트', () {


### PR DESCRIPTION
## 🔍 개요 (Summary)

- Search Bar 위젯 생성
- Search Bar 테스트 생성

---

## ✅ 변경 사항 (Changes)

- 메소드 이름은 searchBar가 내부 material 툴과 겹쳐서 ``SearchBarWidget``으로 대체함
- 테두리 무색으로 변경

---

## 📸 스크린샷 (Screenshots, 선택사항)

>  ![image](https://github.com/user-attachments/assets/70b7dd56-e79f-49d9-86c7-a5502d8e8084)

---

## 🔗 관련 이슈 (Related Issues)

- Closes #77 

---

## 🧪 테스트 (Test)

- [x] SearchBarWidget 이 제대로 생성되는지 테스트
- [x] 검색 입력 시 onChanged 콜백이 호출되는지 테스트

---

## 👀 리뷰어 체크리스트 (For Reviewer)

- [ ] 기능이 명세에 맞게 동작하는지 확인
- [ ] 불필요한 코드/주석이 없는지 확인
- [ ] 테스트가 적절히 작성되었는지 확인
