### PR TITLE
#76 edit bottom sheet 컴포넌트 구현

### DIFF
--- a/lib/presentation/component/edit_bottom_sheet.dart
+++ b/lib/presentation/component/edit_bottom_sheet.dart
@@ -38,8 +38,7 @@ class _EditBottomSheetState extends State<EditBottomSheet> {
   final TextEditingController commentController = TextEditingController();
   final TextEditingController journalController = TextEditingController();
 
-  String _formattedDateTime() =>
-      '${widget.dateTime.formDateString()}, ${widget.dateTime.year} • ${widget.dateTime.hour}:${widget.dateTime.minute.toString().padLeft(2, '0')} ${widget.dateTime.formMeridiem()}';
+  String _formattedDateTime() => widget.dateTime.formatDateTimeString();
 
   @override
   void dispose() {

--- a/lib/presentation/component/edit_bottom_sheet.dart
+++ b/lib/presentation/component/edit_bottom_sheet.dart
@@ -1,0 +1,210 @@
+import 'package:flutter/material.dart';
+import 'package:photopin/core/enums/button_type.dart';
+import 'package:photopin/core/styles/app_color.dart';
+import 'package:photopin/core/styles/app_font.dart';
+import 'package:photopin/presentation/component/base_icon.dart';
+import 'package:photopin/core/extensions/datetime_extension.dart';
+import 'package:photopin/presentation/component/base_icon_button.dart';
+import 'package:photopin/presentation/component/text_limit_input_field.dart';
+
+class EditBottomSheet extends StatefulWidget {
+  final String imageUrl;
+  final DateTime dateTime;
+  final String comment;
+  final List<String> journalNames;
+
+  final VoidCallback onTapClose;
+  final Function(String journalName, String comment) onTapApply;
+  final VoidCallback onTapCancel;
+  final VoidCallback? onClosing;
+
+  const EditBottomSheet({
+    super.key,
+    required this.imageUrl,
+    required this.dateTime,
+    required this.comment,
+    required this.onTapClose,
+    required this.onTapApply,
+    required this.onTapCancel,
+    required this.journalNames,
+    this.onClosing,
+  });
+
+  @override
+  State<EditBottomSheet> createState() => _EditBottomSheetState();
+}
+
+class _EditBottomSheetState extends State<EditBottomSheet> {
+  final TextEditingController commentController = TextEditingController();
+  final TextEditingController journalController = TextEditingController();
+
+  String _formattedDateTime() =>
+      '${widget.dateTime.formDateString()}, ${widget.dateTime.year} • ${widget.dateTime.hour}:${widget.dateTime.minute.toString().padLeft(2, '0')} ${widget.dateTime.formMeridiem()}';
+
+  @override
+  void dispose() {
+    widget.onClosing?.call();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomSheet(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      backgroundColor: AppColors.white,
+      builder: (context) {
+        return SingleChildScrollView(
+          padding: EdgeInsets.only(
+            left: 16,
+            top: 16,
+            right: 16,
+            bottom: 16 + MediaQuery.of(context).viewPadding.bottom,
+          ),
+          child: Column(
+            spacing: 16,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Text(
+                    'Edit',
+                    style: AppFonts.mediumTextBold.copyWith(
+                      color: AppColors.textColor,
+                    ),
+                  ),
+                  const Spacer(),
+                  GestureDetector(
+                    onTap: () {
+                      widget.onTapClose();
+                    },
+                    child: const Icon(
+                      Icons.close,
+                      size: 20,
+                      color: AppColors.gray2,
+                    ),
+                  ),
+                ],
+              ),
+              AspectRatio(
+                // TODO: 현재는 고정으로 16:9 비율, 추후 카메라 기능 들어오면 수정
+                aspectRatio: 16 / 9,
+                child: Container(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(10),
+                    image: DecorationImage(
+                      image: NetworkImage(widget.imageUrl),
+                      fit: BoxFit.cover,
+                    ),
+                  ),
+                ),
+              ),
+              Column(
+                spacing: 12,
+                children: [
+                  Row(
+                    spacing: 12,
+                    children: [
+                      const BaseIcon(
+                        iconColor: AppColors.primary80,
+                        size: 16,
+                        iconData: Icons.calendar_month,
+                      ),
+                      Text(
+                        _formattedDateTime(),
+                        style: AppFonts.smallTextRegular,
+                      ),
+                    ],
+                  ),
+                  Row(
+                    spacing: 12,
+                    children: [
+                      const BaseIcon(
+                        iconColor: AppColors.secondary100,
+                        size: 16,
+                        iconData: Icons.comment,
+                      ),
+                      Expanded(
+                        child: TextLimitInputField(
+                          value: widget.comment,
+                          controller: commentController,
+                          hintText: 'Write Comment',
+                          maxLength: 30,
+                        ),
+                      ),
+                    ],
+                  ),
+                  Row(
+                    children: [
+                      const BaseIcon(
+                        iconColor: AppColors.primary80,
+                        size: 16,
+                        iconData: Icons.note,
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: DropdownMenu<String>(
+                          controller: journalController,
+                          inputDecorationTheme: const InputDecorationTheme(
+                            contentPadding: EdgeInsets.zero,
+                            border: InputBorder.none,
+                          ),
+                          initialSelection: widget.journalNames[0],
+                          menuStyle: MenuStyle(
+                            backgroundColor: WidgetStateProperty.all(
+                              AppColors.white,
+                            ),
+                            padding: WidgetStateProperty.all(EdgeInsets.zero),
+                            elevation: WidgetStateProperty.all(2),
+                          ),
+                          textStyle: AppFonts.smallTextRegular,
+                          dropdownMenuEntries: List.generate(
+                            widget.journalNames.length,
+                            (int index) {
+                              return DropdownMenuEntry(
+                                label: widget.journalNames[index],
+                                value: widget.journalNames[index],
+                              );
+                            },
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              Row(
+                spacing: 12,
+                children: [
+                  Expanded(
+                    child: BaseIconButton(
+                      buttonType: ButtonType.small,
+                      buttonColor: AppColors.primary100,
+                      iconName: Icons.edit,
+                      buttonName: 'Apply',
+                      onClick: () {
+                        widget.onTapApply(
+                          journalController.text,
+                          commentController.text,
+                        );
+                      },
+                    ),
+                  ),
+                  Expanded(
+                    child: BaseIconButton(
+                      buttonType: ButtonType.small,
+                      buttonColor: AppColors.warning,
+                      iconName: Icons.cancel,
+                      buttonName: 'Cancel',
+                      onClick: widget.onTapCancel,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+      },
+      onClosing: () {},
+    );
+  }
+}

--- a/lib/presentation/component/edit_bottom_sheet.dart
+++ b/lib/presentation/component/edit_bottom_sheet.dart
@@ -41,6 +41,12 @@ class _EditBottomSheetState extends State<EditBottomSheet> {
   String _formattedDateTime() => widget.dateTime.formatDateTimeString();
 
   @override
+  void initState() {
+    super.initState();
+    commentController.value = TextEditingValue(text: widget.comment);
+  }
+
+  @override
   void dispose() {
     widget.onClosing?.call();
     commentController.dispose();
@@ -126,7 +132,6 @@ class _EditBottomSheetState extends State<EditBottomSheet> {
                       ),
                       Expanded(
                         child: TextLimitInputField(
-                          value: widget.comment,
                           controller: commentController,
                           hintText: 'Write Comment',
                           maxLength: 30,

--- a/lib/presentation/component/edit_bottom_sheet.dart
+++ b/lib/presentation/component/edit_bottom_sheet.dart
@@ -44,6 +44,8 @@ class _EditBottomSheetState extends State<EditBottomSheet> {
   @override
   void dispose() {
     widget.onClosing?.call();
+    commentController.dispose();
+    journalController.dispose();
     super.dispose();
   }
 

--- a/lib/presentation/component/text_limit_input_field.dart
+++ b/lib/presentation/component/text_limit_input_field.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:photopin/core/styles/app_color.dart';
+import 'package:photopin/core/styles/app_font.dart';
+
+class TextLimitInputField extends StatefulWidget {
+  final String value;
+  final String hintText;
+  final int maxLength;
+  final TextEditingController controller;
+
+  const TextLimitInputField({
+    super.key,
+    required this.value,
+    required this.controller,
+    this.maxLength = 0,
+    this.hintText = '',
+  });
+
+  @override
+  State<TextLimitInputField> createState() => _TextLimitInputFieldState();
+}
+
+class _TextLimitInputFieldState extends State<TextLimitInputField> {
+  late final TextEditingController _controller;
+
+  @override
+  initState() {
+    super.initState();
+    _controller = widget.controller;
+    _controller.value = TextEditingValue(text: widget.value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      onChanged: (String a) {
+        setState(() {});
+      },
+      style: AppFonts.smallTextRegular,
+      controller: _controller,
+      decoration: InputDecoration(
+        hintText: widget.hintText,
+        isDense: true,
+        suffixText:
+            widget.maxLength != 0
+                ? '${widget.controller.text.length}/${widget.maxLength}'
+                : '',
+        suffixStyle: AppFonts.smallTextRegular.copyWith(
+          fontSize: 12,
+          color:
+              widget.maxLength != 0 &&
+                      widget.controller.text.length > widget.maxLength
+                  ? AppColors.warning
+                  : AppColors.black,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/component/text_limit_input_field.dart
+++ b/lib/presentation/component/text_limit_input_field.dart
@@ -3,14 +3,12 @@ import 'package:photopin/core/styles/app_color.dart';
 import 'package:photopin/core/styles/app_font.dart';
 
 class TextLimitInputField extends StatefulWidget {
-  final String value;
   final String hintText;
   final int maxLength;
   final TextEditingController controller;
 
   const TextLimitInputField({
     super.key,
-    required this.value,
     required this.controller,
     this.maxLength = 0,
     this.hintText = '',
@@ -21,23 +19,15 @@ class TextLimitInputField extends StatefulWidget {
 }
 
 class _TextLimitInputFieldState extends State<TextLimitInputField> {
-  late final TextEditingController _controller;
-
-  @override
-  initState() {
-    super.initState();
-    _controller = widget.controller;
-    _controller.value = TextEditingValue(text: widget.value);
-  }
-
   @override
   Widget build(BuildContext context) {
     return TextField(
-      onChanged: (String a) {
+      onChanged: (String value) {
+        // TextField 재빌드용 setState 호출
         setState(() {});
       },
       style: AppFonts.smallTextRegular,
-      controller: _controller,
+      controller: widget.controller,
       decoration: InputDecoration(
         hintText: widget.hintText,
         isDense: true,

--- a/test/presentation/component/edit_bottom_sheet_test.dart
+++ b/test/presentation/component/edit_bottom_sheet_test.dart
@@ -1,0 +1,258 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:network_image_mock/network_image_mock.dart';
+import 'package:photopin/core/enums/button_type.dart';
+import 'package:photopin/presentation/component/base_button.dart';
+import 'package:photopin/presentation/component/edit_bottom_sheet.dart';
+import 'package:photopin/presentation/component/text_limit_input_field.dart';
+
+final String comment = 'A';
+final List<String> journalNames = ['Journal 1', 'Journal 2'];
+final String imageUrl = '';
+final DateTime dateTime = DateTime(2025, 05, 07, 15, 30);
+
+void main() {
+  testWidgets('버튼 클릭 시 EditBottomSheet가 열리고 구성 요소가 정상적으로 보여야한다.', (
+    WidgetTester tester,
+  ) async {
+    await mockNetworkImagesFor(() async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                return SafeArea(
+                  child: Center(
+                    child: BaseButton(
+                      buttonName: 'Open Bottom Sheet',
+                      onClick: () {
+                        showModalBottomSheet(
+                          builder: (BuildContext context) {
+                            return EditBottomSheet(
+                              comment: comment,
+                              dateTime: dateTime,
+                              journalNames: journalNames,
+                              imageUrl: imageUrl,
+                              onTapApply:
+                                  (String journalName, String comment) {},
+                              onTapCancel: () {},
+                              onTapClose: () {},
+                            );
+                          },
+                          context: context,
+                        );
+                      },
+                      buttonType: ButtonType.small,
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Open Bottom Sheet'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(EditBottomSheet), findsOneWidget);
+      expect(find.text(comment), findsOneWidget);
+      expect(find.byIcon(Icons.calendar_month), findsOneWidget);
+      expect(find.byIcon(Icons.comment), findsOneWidget);
+      expect(find.byIcon(Icons.edit), findsOneWidget);
+      expect(find.byIcon(Icons.note), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pumpAndSettle();
+    });
+  });
+
+  testWidgets(
+    'EditBottomSheet의 close 아이콘을 탭하면 onTapClose 콜백과 onClosing 콜백이 호출되고 EditBottomSheet가 닫혀야한다.',
+    (WidgetTester tester) async {
+      bool tappedClose = false;
+      bool calledClosing = false;
+
+      await mockNetworkImagesFor(() async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (context) {
+                  return SafeArea(
+                    child: Center(
+                      child: BaseButton(
+                        buttonName: 'Open Bottom Sheet',
+                        onClick: () {
+                          showModalBottomSheet(
+                            builder: (BuildContext context) {
+                              return EditBottomSheet(
+                                comment: comment,
+                                dateTime: dateTime,
+                                journalNames: journalNames,
+                                imageUrl: imageUrl,
+                                onTapApply:
+                                    (String journalName, String comment) {},
+                                onTapCancel: () {},
+                                onClosing: () => calledClosing = true,
+                                onTapClose: () {
+                                  tappedClose = true;
+                                  Navigator.pop(context);
+                                },
+                              );
+                            },
+                            context: context,
+                          );
+                        },
+                        buttonType: ButtonType.small,
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Open Bottom Sheet'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byIcon(Icons.close));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.byType(EditBottomSheet),
+          findsNothing,
+          reason: 'EditBottomSheet가 닫히지 않음',
+        );
+        expect(tappedClose, true, reason: 'tappedClose가 true로 변경되지 않음');
+        expect(calledClosing, true, reason: 'calledClosing이 true로 변경되지 않음');
+      });
+    },
+  );
+
+  testWidgets(
+    'EditBottomSheet를 변경하고 Apply를 탭하면 onTapApply 콜백 함수로 journalName과 comment의 값이 반환되야한다.',
+    (WidgetTester tester) async {
+      await mockNetworkImagesFor(() async {
+        String expectJournalName = '';
+        String expectComment = '';
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (context) {
+                  return SafeArea(
+                    child: Center(
+                      child: BaseButton(
+                        buttonName: 'Open Bottom Sheet',
+                        onClick: () {
+                          showModalBottomSheet(
+                            builder: (BuildContext context) {
+                              return EditBottomSheet(
+                                comment: comment,
+                                dateTime: dateTime,
+                                journalNames: journalNames,
+                                imageUrl: imageUrl,
+                                onTapApply: (
+                                  String journalName,
+                                  String comment,
+                                ) {
+                                  expectJournalName = journalName;
+                                  expectComment = comment;
+                                },
+                                onTapCancel: () {},
+                                onClosing: () {},
+                                onTapClose: () {},
+                              );
+                            },
+                            context: context,
+                          );
+                        },
+                        buttonType: ButtonType.small,
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Open Bottom Sheet'));
+        await tester.pumpAndSettle();
+
+        await tester.enterText(find.byType(TextLimitInputField), 'Hello');
+        await tester.pumpAndSettle();
+
+        await tester.ensureVisible(find.text('Apply'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Apply'));
+        await tester.pumpAndSettle();
+
+        expect(expectComment, 'Hello');
+        expect(expectJournalName, journalNames[0]);
+      });
+    },
+  );
+
+  testWidgets('EditBottomSheet의 Cancel을 탭하면 onTapCancel 콜백이 호출되야한다.', (
+    WidgetTester tester,
+  ) async {
+    await mockNetworkImagesFor(() async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                return SafeArea(
+                  child: Center(
+                    child: BaseButton(
+                      buttonName: 'Open Bottom Sheet',
+                      onClick: () {
+                        showModalBottomSheet(
+                          builder: (BuildContext context) {
+                            return EditBottomSheet(
+                              comment: comment,
+                              dateTime: dateTime,
+                              journalNames: journalNames,
+                              imageUrl: imageUrl,
+                              onTapApply:
+                                  (String journalName, String comment) {},
+                              onTapCancel: () {
+                                Navigator.pop(context);
+                              },
+                              onClosing: () {},
+                              onTapClose: () {},
+                            );
+                          },
+                          context: context,
+                        );
+                      },
+                      buttonType: ButtonType.small,
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Open Bottom Sheet'));
+      await tester.pumpAndSettle();
+
+      await tester.ensureVisible(find.text('Cancel'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byType(EditBottomSheet),
+        findsNothing,
+        reason: 'EditBottomSheet가 닫히지 않음',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 🔍 개요 (Summary)

- `EditBottomSheet` 컴포넌트 구현
- `TextLimitInputField` 컴포넌트 구현
- `EditBottomSheet` 위젯 테스트 코드 작성
---

## 📸 스크린샷 (Screenshots, 선택사항)

<img width="411" alt="image" src="https://github.com/user-attachments/assets/d5020b6a-addb-47dc-b799-fae066a0af4e" />

---

## 🔗 관련 이슈 (Related Issues)

Closes #76 

---

## 🧪 테스트 (Test)

- `EditBottomSheet` 위젯 테스트 작성
  - 버튼 클릭 시 `EditBottomSheet`가 열리고 구성 요소가 정상적으로 보이는지 테스트
  - `EditBottomSheet`의 close 아이콘을 탭하면 onTapClose 콜백과 onClosing 콜백이 호출되고 EditBottomSheet가 닫히는지 테스트
- `EditBottomSheet`의 내용을 변경하고 Apply를 탭하면 onTapApply 콜백 함수로 journalName과 comment의 값이 반환되는지 테스트

---

## 👀 리뷰어 체크리스트 (For Reviewer)

- [ ] 기능이 명세에 맞게 동작하는지 확인
- [ ] 불필요한 코드/주석이 없는지 확인
- [ ] 테스트가 적절히 작성되었는지 확인
