### PR TITLE
#97 feat data source create

### DIFF
--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -1,0 +1,5 @@
+import 'package:get_it/get_it.dart';
+
+final getIt = GetIt.instance;
+
+void di() {}

--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -1,5 +1,8 @@
 import 'package:get_it/get_it.dart';
+import 'package:photopin/core/firebase/firestore_setup.dart';
 
 final getIt = GetIt.instance;
 
-void di() {}
+void di() {
+  getIt.registerLazySingleton<FirestoreSetup>(() => FirestoreSetup());
+}

--- a/lib/core/errors/firestore_error.dart
+++ b/lib/core/errors/firestore_error.dart
@@ -1,0 +1,8 @@
+enum FirestoreError implements Exception {
+  notFoundError('데이터가 존재하지 않습니다.'),
+  timeOutError('timeout');
+
+  final String message;
+
+  const FirestoreError(this.message);
+}

--- a/lib/core/firebase/firestore_collections.dart
+++ b/lib/core/firebase/firestore_collections.dart
@@ -1,0 +1,5 @@
+abstract class FirestoreCollections {
+  static const String userCollection = 'users';
+  static const String photoCollection = 'photos';
+  static const String journalCollection = 'journals';
+}

--- a/lib/core/firebase/firestore_setup.dart
+++ b/lib/core/firebase/firestore_setup.dart
@@ -1,0 +1,18 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:photopin/core/firebase/firestore_collections.dart';
+import 'package:photopin/photo/data/dto/photo_dto.dart';
+
+class FirestoreSetup {
+  final FirebaseFirestore firestore = FirebaseFirestore.instance;
+
+  CollectionReference<PhotoDto> photoFirestore(String userId) {
+    return firestore
+        .collection(FirestoreCollections.userCollection)
+        .doc(userId)
+        .collection(FirestoreCollections.photoCollection)
+        .withConverter(
+          fromFirestore: (snapShot, _) => PhotoDto.fromJson(snapShot.data()!),
+          toFirestore: (dto, _) => dto.toJson(),
+        );
+  }
+}

--- a/lib/photo/data/data_source/photo_data_source.dart
+++ b/lib/photo/data/data_source/photo_data_source.dart
@@ -1,0 +1,9 @@
+import 'package:photopin/photo/data/dto/photo_dto.dart';
+
+abstract interface class PhotoDataSource {
+  Future<List<PhotoDto>> findPhotosByJournalId(String journalId);
+  Future<PhotoDto> findPhotoById(String id);
+  Future<List<PhotoDto>> findPhotos();
+  Future<void> savePhoto(PhotoDto dto);
+  Future<void> deletePhoto(String photoId);
+}

--- a/lib/photo/data/data_source/photo_data_source_impl.dart
+++ b/lib/photo/data/data_source/photo_data_source_impl.dart
@@ -1,0 +1,71 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:photopin/core/errors/firestore_error.dart';
+import 'package:photopin/photo/data/data_source/photo_data_source.dart';
+import 'package:photopin/photo/data/dto/photo_dto.dart';
+
+class PhotoDataSourceImpl implements PhotoDataSource {
+  final CollectionReference<PhotoDto> photoStore;
+
+  PhotoDataSourceImpl({required this.photoStore});
+
+  @override
+  Future<PhotoDto> findPhotoById(String id) async {
+    final QuerySnapshot<PhotoDto> snapshot = await photoStore
+        .where('id', isEqualTo: id)
+        .get()
+        .timeout(
+          const Duration(seconds: 8),
+          onTimeout: () => throw FirestoreError.timeOutError,
+        );
+
+    for (final docSnapshot in snapshot.docs) {
+      return docSnapshot.data();
+    }
+
+    throw FirestoreError.notFoundError;
+  }
+
+  @override
+  Future<List<PhotoDto>> findPhotos() async {
+    final List<PhotoDto> photoDtos = [];
+
+    final QuerySnapshot<PhotoDto> snapshot = await photoStore.get().timeout(
+      const Duration(seconds: 8),
+      onTimeout: () => throw FirestoreError.timeOutError,
+    );
+
+    snapshot.docs.map((e) => photoDtos.add(e.data()));
+
+    return photoDtos;
+  }
+
+  @override
+  Future<List<PhotoDto>> findPhotosByJournalId(String journalId) async {
+    final List<PhotoDto> photoDtos = [];
+
+    final QuerySnapshot<PhotoDto> snapshot = await photoStore
+        .where('journalId', isEqualTo: journalId)
+        .get()
+        .timeout(
+          const Duration(seconds: 8),
+          onTimeout: () => throw FirestoreError.timeOutError,
+        );
+
+    snapshot.docs.map((e) => photoDtos.add(e.data()));
+
+    return photoDtos;
+  }
+
+  @override
+  Future<void> deletePhoto(String photoId) async {
+    await photoStore.doc(photoId).delete();
+  }
+
+  @override
+  Future<void> savePhoto(PhotoDto dto) async {
+    final DocumentReference<PhotoDto> photodoc = await photoStore.add(dto);
+    final String docId = photodoc.id;
+
+    await photoStore.doc(docId).update({'id': docId});
+  }
+}

--- a/lib/photo/data/dto/photo_dto.dart
+++ b/lib/photo/data/dto/photo_dto.dart
@@ -1,12 +1,11 @@
-import 'package:photopin/location/data/dto/location_dto.dart';
-
 class PhotoDto {
   final String? id;
   final String? name;
   final DateTime? dateTime;
   final String? journalId;
   final String? imageUrl;
-  final LocationDto? location;
+  final double? latitude;
+  final double? longitude;
   final String? comment;
 
   const PhotoDto({
@@ -15,7 +14,8 @@ class PhotoDto {
     this.dateTime,
     this.journalId,
     this.imageUrl,
-    this.location,
+    this.latitude,
+    this.longitude,
     this.comment,
   });
 
@@ -25,7 +25,8 @@ class PhotoDto {
     dateTime: json['dateTime'],
     journalId: json['journalId'],
     imageUrl: json['imageUrl'],
-    location: LocationDto.fromJson(json['location']),
+    latitude: json['latitude'],
+    longitude: json['longitude'],
     comment: json['comment'],
   );
 
@@ -35,7 +36,8 @@ class PhotoDto {
     'dateTime': dateTime,
     'journalId': journalId,
     'imageUrl': imageUrl,
-    'location': location?.toJson(),
+    'latitude': latitude,
+    'longitude': longitude,
     'comment': comment,
   };
 }

--- a/lib/photo/data/mapper/photo_mapper.dart
+++ b/lib/photo/data/mapper/photo_mapper.dart
@@ -1,4 +1,3 @@
-import 'package:photopin/location/data/mapper/location_mapper.dart';
 import 'package:photopin/location/domain/model/location_model.dart';
 import 'package:photopin/photo/data/dto/photo_dto.dart';
 import 'package:photopin/photo/domain/model/photo_model.dart';
@@ -11,8 +10,10 @@ extension PhotoMapper on PhotoDto {
       dateTime: dateTime ?? DateTime(1999, 1, 1),
       journalId: journalId ?? 'N/A',
       imageUrl: imageUrl ?? 'N/A',
-      location:
-          location?.toModel() ?? const LocationModel(latitude: 0, longitude: 0),
+      location: LocationModel(
+        latitude: latitude ?? 0,
+        longitude: longitude ?? 0,
+      ),
       comment: comment ?? 'N/A',
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   firebase_auth: ^5.5.3
   get_it: ^8.0.3
   derry: ^1.5.0
+  mocktail: ^1.0.4
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   firebase_core: ^3.13.0
   cloud_firestore: ^5.6.7
   firebase_auth: ^5.5.3
+  get_it: ^8.0.3
 
 dev_dependencies:
   flutter_test:

--- a/test/photo/data/data_source/mock_photo_data_source_impl.dart
+++ b/test/photo/data/data_source/mock_photo_data_source_impl.dart
@@ -1,0 +1,4 @@
+import 'package:mocktail/mocktail.dart';
+import 'package:photopin/photo/data/data_source/photo_data_source.dart';
+
+class MockPhotoDataSourceImpl extends Mock implements PhotoDataSource {}

--- a/test/photo/data/data_source/photo_data_source_test.dart
+++ b/test/photo/data/data_source/photo_data_source_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:photopin/photo/data/data_source/photo_data_source.dart';
+import 'package:photopin/photo/data/dto/photo_dto.dart';
+
+import 'mock_photo_data_source_impl.dart';
+
+void main() async {
+  late final PhotoDataSource photoDataSource;
+  final String photoId = '1';
+  final String journalId = 'journal1';
+  final PhotoDto dto = PhotoDto(
+    id: '5',
+    comment: 'test5',
+    dateTime: DateTime.now(),
+    imageUrl: '',
+    journalId: 'journal2',
+    latitude: 12.343,
+    longitude: 43.12,
+    name: 'test Photo5',
+  );
+  final List<PhotoDto> photos = [
+    PhotoDto(
+      id: '1',
+      comment: 'test1',
+      dateTime: DateTime.now(),
+      imageUrl: '',
+      journalId: journalId,
+      latitude: 12.343,
+      longitude: 43.12,
+      name: 'test Photo1',
+    ),
+    PhotoDto(
+      id: '2',
+      comment: 'test2',
+      dateTime: DateTime(2025),
+      imageUrl: '',
+      journalId: journalId,
+      latitude: 0.1212,
+      longitude: 0.435,
+      name: 'test Photo2',
+    ),
+    PhotoDto(
+      id: '3',
+      comment: 'test3',
+      dateTime: DateTime.now(),
+      imageUrl: '',
+      journalId: journalId,
+      latitude: 10.23,
+      longitude: 0.555,
+      name: 'test Photo3',
+    ),
+    PhotoDto(
+      id: '4',
+      comment: 'test4',
+      dateTime: DateTime.now(),
+      imageUrl: '',
+      journalId: 'journal2',
+      latitude: 0.1,
+      longitude: 0.23,
+      name: 'test Photo4',
+    ),
+  ];
+
+  setUpAll(() {
+    photoDataSource = MockPhotoDataSourceImpl();
+    when(() => photoDataSource.savePhoto(dto)).thenAnswer((_) async {
+      photos.add(dto);
+    });
+    when(() => photoDataSource.findPhotos()).thenAnswer((_) async => photos);
+    when(
+      () => photoDataSource.findPhotoById(photoId),
+    ).thenAnswer((_) async => photos.firstWhere((dto) => dto.id == photoId));
+    when(() => photoDataSource.findPhotosByJournalId(journalId)).thenAnswer(
+      (_) async => photos.where((dto) => dto.journalId == journalId).toList(),
+    );
+    when(() => photoDataSource.deletePhoto(photoId)).thenAnswer((_) async {
+      photos.removeWhere((dto) => dto.id == photoId);
+    });
+  });
+
+  test('저장된 리스트를 제대로 가져와야한다.', () async {
+    final List<PhotoDto> dtos = await photoDataSource.findPhotos();
+
+    expect(dtos, photos);
+  });
+
+  test('저장된 리스트에서 journalId를 이용해 데이터를 제대로 가져와야한다.', () async {
+    final List<PhotoDto> dtos = await photoDataSource.findPhotosByJournalId(
+      journalId,
+    );
+
+    expect(dtos, photos.where((dto) => dto.journalId == journalId).toList());
+  });
+
+  test('저장된 리스트에서 id를 이용해 데이터를 제대로 가져와야한다.', () async {
+    final PhotoDto dto = await photoDataSource.findPhotoById(photoId);
+
+    expect(dto, photos.firstWhere((dto) => dto.id == photoId));
+  });
+
+  test('photo data이(가) 제대로 들어가야한다.', () async {
+    await photoDataSource.savePhoto(dto);
+
+    expect(await photoDataSource.findPhotos(), photos);
+  });
+
+  test('photo data이(가) 제대로 삭제되어야한다.', () async {
+    await photoDataSource.deletePhoto(photoId);
+
+    expect(photos.any((dto) => dto.id == photoId), false);
+  });
+}


### PR DESCRIPTION
## 🔍 개요 (Summary)

- photo data source create
- firestore error custom error create

---

## ✅ 변경 사항 (Changes)

- photo data source create
    - photo data source interface create
    - photo data source implement create
    - mock photo data source create
    - photo data source test code create
- firestore error custom error create

---

## 🔗 관련 이슈 (Related Issues)

#97 

---

## 🧪 테스트 (Test)

- [x] 저장된 리스트를 제대로 가져와야한다.
- [x] 저장된 리스트에서 journalId를 이용해 데이터를 제대로 가져와야한다.
- [x] 저장된 리스트에서 id를 이용해 데이터를 제대로 가져와야한다.
- [x] photo data이(가) 제대로 들어가야한다.
- [x] photo data이(가) 제대로 삭제되어야한다.

## 📝 참고 사항 (Notes)

- 리뷰어가 이해하는 데 도움이 될 만한 기타 정보
- 논의가 필요한 부분이나 리뷰 요청 포인트 등

---

## 👀 리뷰어 체크리스트 (For Reviewer)

- [ ] 기능이 명세에 맞게 동작하는지 확인
- [ ] 불필요한 코드/주석이 없는지 확인
- [ ] 테스트가 적절히 작성되었는지 확인
