### PR TITLE
#113 User Repository 구현

### DIFF
--- a/lib/core/data/repository.dart
+++ b/lib/core/data/repository.dart
@@ -1,5 +1,4 @@
 abstract interface class Repository<T, ID, DTO> {
   Future<T?> findOne(ID id);
-  Future<T?> findByFilter(bool Function(T predicate) predicate);
   Future<List<T>> findAll();
 }

--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -1,8 +1,18 @@
 import 'package:get_it/get_it.dart';
 import 'package:photopin/core/firebase/firestore_setup.dart';
+import 'package:photopin/user/data/data_source/user_data_source.dart';
+import 'package:photopin/user/data/data_source/user_data_source_impl.dart';
+import 'package:photopin/user/data/repository/user_repository.dart';
+import 'package:photopin/user/data/repository/user_repository_impl.dart';
 
 final getIt = GetIt.instance;
 
 void di() {
+  getIt.registerSingleton<UserDataSource>(
+    UserDataSourceImpl(userStore: getIt.get<FirestoreSetup>().userFirestore()),
+  );
+
+  getIt.registerSingleton<UserRepository>(UserRepositoryImpl(getIt()));
+
   getIt.registerLazySingleton<FirestoreSetup>(() => FirestoreSetup());
 }

--- a/lib/user/data/repository/user_repository.dart
+++ b/lib/user/data/repository/user_repository.dart
@@ -1,0 +1,6 @@
+import 'package:photopin/core/data/repository.dart';
+import 'package:photopin/user/data/dto/user_dto.dart';
+import 'package:photopin/user/domain/model/user_model.dart';
+
+abstract interface class UserRepository
+    implements Repository<UserModel, String, UserDto> {}

--- a/lib/user/data/repository/user_repository_impl.dart
+++ b/lib/user/data/repository/user_repository_impl.dart
@@ -1,0 +1,32 @@
+import 'package:photopin/user/data/data_source/user_data_source.dart';
+import 'package:photopin/user/data/dto/user_dto.dart';
+import 'package:photopin/user/data/mapper/user_mapper.dart';
+import 'package:photopin/user/data/repository/user_repository.dart';
+import 'package:photopin/user/domain/model/user_model.dart';
+
+class UserRepositoryImpl implements UserRepository {
+  final UserDataSource _dataSource;
+
+  const UserRepositoryImpl(this._dataSource);
+
+  @override
+  Future<List<UserModel>> findAll() async {
+    List<UserDto> userDtos = await _dataSource.findUsers();
+    return userDtos.map((dto) => dto.toModel()).toList();
+  }
+
+  @override
+  Future<UserModel?> findByFilter(
+    bool Function(UserModel predicate) predicate,
+  ) async {
+    // TODO: 추후 조건으로 검색할 수 있게 DataSource 레벨에서부터 변경이 필요함
+    List<UserModel> users = await findAll();
+    return users.firstWhere(predicate);
+  }
+
+  @override
+  Future<UserModel?> findOne(String id) async {
+    UserDto dto = await _dataSource.findUserById(id);
+    return dto.toModel();
+  }
+}

--- a/lib/user/data/repository/user_repository_impl.dart
+++ b/lib/user/data/repository/user_repository_impl.dart
@@ -16,15 +16,6 @@ class UserRepositoryImpl implements UserRepository {
   }
 
   @override
-  Future<UserModel?> findByFilter(
-    bool Function(UserModel predicate) predicate,
-  ) async {
-    // TODO: 추후 조건으로 검색할 수 있게 DataSource 레벨에서부터 변경이 필요함
-    List<UserModel> users = await findAll();
-    return users.firstWhere(predicate);
-  }
-
-  @override
   Future<UserModel?> findOne(String id) async {
     UserDto dto = await _dataSource.findUserById(id);
     return dto.toModel();

--- a/test/user/data/data_source/mock_user_data_source.dart
+++ b/test/user/data/data_source/mock_user_data_source.dart
@@ -1,0 +1,4 @@
+import 'package:mocktail/mocktail.dart';
+import 'package:photopin/user/data/data_source/user_data_source.dart';
+
+class MockUserDataSource extends Mock implements UserDataSource {}

--- a/test/user/data/repository/user_repository_test.dart
+++ b/test/user/data/repository/user_repository_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:photopin/user/data/data_source/user_data_source.dart';
+import 'package:photopin/user/data/dto/user_dto.dart';
+import 'package:photopin/user/data/repository/user_repository.dart';
+import 'package:photopin/user/data/repository/user_repository_impl.dart';
+import 'package:photopin/user/domain/model/user_model.dart';
+
+import '../../fixtures/user_dto_fixtures.dart';
+import '../data_source/mock_user_data_source.dart';
+
+void main() {
+  late UserRepository repository;
+  final UserDataSource dataSource = MockUserDataSource();
+
+  setUp(() {
+    repository = UserRepositoryImpl(dataSource);
+  });
+
+  setUpAll(() {
+    when(() => dataSource.findUsers()).thenAnswer((_) async {
+      return userDtoFixtures;
+    });
+  });
+
+  test('findAll을 호출하면 List<UserModel> 형태로 반환해야한다.', () async {
+    List<UserModel> users = await repository.findAll();
+
+    verify(() => dataSource.findUsers()).called(1);
+    expect(users.length, 2);
+  });
+
+  test('findById를 호출하면 인자로 전달한 ID에 해당하는 UserModel을 반환해야한다.', () async {
+    // GIVEN
+    when(() => dataSource.findUserById(any())).thenAnswer((invocation) async {
+      final String id = invocation.positionalArguments[0] as String;
+      return userDtoFixtures.firstWhere((e) => e.id == id);
+    });
+
+    UserDto target = userDtoFixtures.first;
+
+    // WHEN
+    UserModel? user = await repository.findOne(target.id!);
+
+    // THEN
+    verify(() => dataSource.findUserById(target.id!)).called(1);
+    expect(user, isNotNull);
+    expect(user?.id, target.id);
+    expect(user?.email, 'example1@example.com');
+  });
+
+  test('findByFilter를 호출하면 인자로 전달한 조건에 해당하는 UserModel을 반환해야한다.', () async {
+    // GIVEN
+    UserDto target = userDtoFixtures.last;
+
+    // WHEN
+    UserModel? user = await repository.findByFilter(
+      (e) => e.email == target.email,
+    );
+
+    // THEN
+    verify(() => dataSource.findUsers()).called(1);
+    expect(user, isNotNull);
+    expect(user?.id, target.id);
+    expect(user?.email, target.email);
+  });
+}

--- a/test/user/data/repository/user_repository_test.dart
+++ b/test/user/data/repository/user_repository_test.dart
@@ -27,13 +27,15 @@ void main() {
     List<UserModel> users = await repository.findAll();
 
     verify(() => dataSource.findUsers()).called(1);
-    expect(users.length, 2);
+    expect(users.length, userDtoFixtures.length);
   });
 
   test('findById를 호출하면 인자로 전달한 ID에 해당하는 UserModel을 반환해야한다.', () async {
     // GIVEN
-    when(() => dataSource.findUserById(any())).thenAnswer((invocation) async {
-      final String id = invocation.positionalArguments[0] as String;
+    when(() => dataSource.findUserById(any<String>())).thenAnswer((
+      invocation,
+    ) async {
+      final String id = invocation.positionalArguments.first as String;
       return userDtoFixtures.firstWhere((e) => e.id == id);
     });
 
@@ -46,7 +48,7 @@ void main() {
     verify(() => dataSource.findUserById(target.id!)).called(1);
     expect(user, isNotNull);
     expect(user?.id, target.id);
-    expect(user?.email, 'example1@example.com');
+    expect(user?.email, target.email);
   });
 
   test('findByFilter를 호출하면 인자로 전달한 조건에 해당하는 UserModel을 반환해야한다.', () async {

--- a/test/user/data/repository/user_repository_test.dart
+++ b/test/user/data/repository/user_repository_test.dart
@@ -11,21 +11,23 @@ import '../data_source/mock_user_data_source.dart';
 
 void main() {
   late UserRepository repository;
-  final UserDataSource dataSource = MockUserDataSource();
+  late UserDataSource dataSource;
 
   setUp(() {
+    dataSource = MockUserDataSource();
     repository = UserRepositoryImpl(dataSource);
   });
 
-  setUpAll(() {
+  test('findAll을 호출하면 List<UserModel> 형태로 반환해야한다.', () async {
+    // GIVEN
     when(() => dataSource.findUsers()).thenAnswer((_) async {
       return userDtoFixtures;
     });
-  });
 
-  test('findAll을 호출하면 List<UserModel> 형태로 반환해야한다.', () async {
+    // WHEN
     List<UserModel> users = await repository.findAll();
 
+    // THEN
     verify(() => dataSource.findUsers()).called(1);
     expect(users.length, userDtoFixtures.length);
   });
@@ -46,22 +48,6 @@ void main() {
 
     // THEN
     verify(() => dataSource.findUserById(target.id!)).called(1);
-    expect(user, isNotNull);
-    expect(user?.id, target.id);
-    expect(user?.email, target.email);
-  });
-
-  test('findByFilter를 호출하면 인자로 전달한 조건에 해당하는 UserModel을 반환해야한다.', () async {
-    // GIVEN
-    UserDto target = userDtoFixtures.last;
-
-    // WHEN
-    UserModel? user = await repository.findByFilter(
-      (e) => e.email == target.email,
-    );
-
-    // THEN
-    verify(() => dataSource.findUsers()).called(1);
     expect(user, isNotNull);
     expect(user?.id, target.id);
     expect(user?.email, target.email);

--- a/test/user/fixtures/user_dto_fixtures.dart
+++ b/test/user/fixtures/user_dto_fixtures.dart
@@ -1,0 +1,16 @@
+import 'package:photopin/user/data/dto/user_dto.dart';
+
+const List<UserDto> userDtoFixtures = [
+  UserDto(
+    id: '1',
+    displayName: 'A',
+    email: 'example1@example.com',
+    profileImg: '',
+  ),
+  UserDto(
+    id: '2',
+    displayName: 'B',
+    email: 'example2@example.com',
+    profileImg: '',
+  ),
+];


### PR DESCRIPTION
## 🔍 개요 (Summary)

- `UserRepository` 인터페이스 작성
- `UserRepositoryImpl` 구현체 작성
- `UserRepositoryImpl`을 싱글톤으로 DI 하도록 설정
- 테스트 코드만을 위한 고정된 데이터 `user_dto_fixtures.dart` 추가
- `MockUserDataSource` 작성
- `UserRepository` 유닛 테스트 작성
---
## 🔗 관련 이슈 (Related Issues)

Closes #113 

---

## 🧪 테스트 (Test)

- `UserRepository`의 `findAll` 메서드 테스트
- `UserRepository`의 `findByFilter` 메서드 테스트
- `UserRepository`의 `findOne` 메서드 테스트

## 📝 참고 사항 (Notes)

- 리뷰어가 이해하는 데 도움이 될 만한 기타 정보
- 논의가 필요한 부분이나 리뷰 요청 포인트 등

---

## 👀 리뷰어 체크리스트 (For Reviewer)

- [ ] 기능이 명세에 맞게 동작하는지 확인
- [ ] 불필요한 코드/주석이 없는지 확인
- [ ] 테스트가 적절히 작성되었는지 확인
