### PR TITLE
#112 feat photo repository create

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <application
         android:label="photopin"
         android:name="${applicationName}"
+        android:usesCleartextTraffic="true"
         android:icon="@mipmap/ic_launcher">
         <meta-data
         android:name="com.google.android.geo.API_KEY"

--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -1,8 +1,22 @@
 import 'package:get_it/get_it.dart';
 import 'package:photopin/core/firebase/firestore_setup.dart';
+import 'package:photopin/photo/data/data_source/photo_data_source.dart';
+import 'package:photopin/photo/data/data_source/photo_data_source_impl.dart';
+import 'package:photopin/photo/data/repository/photo_repository.dart';
+import 'package:photopin/photo/data/repository/photo_repository_impl.dart';
 
 final getIt = GetIt.instance;
 
 void di() {
   getIt.registerLazySingleton<FirestoreSetup>(() => FirestoreSetup());
+
+  // userId 마다 firestore에서 받아오는 photo collection 이 달라져야함으로 싱글톤이 의미가 없음.
+  getIt.registerFactoryParam<PhotoDataSource, String, void>(
+    (userId, _) => PhotoDataSourceImpl(
+      photoStore: getIt<FirestoreSetup>().photoFirestore(userId),
+    ),
+  );
+  getIt.registerLazySingleton<PhotoRepository>(
+    () => PhotoRepositoryImpl(dataSource: getIt()),
+  );
 }

--- a/lib/photo/data/data_source/photo_data_source_impl.dart
+++ b/lib/photo/data/data_source/photo_data_source_impl.dart
@@ -6,7 +6,7 @@ import 'package:photopin/photo/data/dto/photo_dto.dart';
 class PhotoDataSourceImpl implements PhotoDataSource {
   final CollectionReference<PhotoDto> photoStore;
 
-  PhotoDataSourceImpl({required this.photoStore});
+  const PhotoDataSourceImpl({required this.photoStore});
 
   @override
   Future<PhotoDto> findPhotoById(String id) async {

--- a/lib/photo/data/mapper/photo_mapper.dart
+++ b/lib/photo/data/mapper/photo_mapper.dart
@@ -18,3 +18,18 @@ extension PhotoMapper on PhotoDto {
     );
   }
 }
+
+extension ModelMapper on PhotoModel {
+  PhotoDto toDto() {
+    return PhotoDto(
+      id: id,
+      comment: comment,
+      dateTime: dateTime,
+      imageUrl: imageUrl,
+      journalId: journalId,
+      latitude: location.latitude,
+      longitude: location.longitude,
+      name: name,
+    );
+  }
+}

--- a/lib/photo/data/repository/photo_repository.dart
+++ b/lib/photo/data/repository/photo_repository.dart
@@ -1,0 +1,14 @@
+import 'package:photopin/core/data/repository.dart';
+import 'package:photopin/photo/data/dto/photo_dto.dart';
+import 'package:photopin/photo/domain/model/photo_model.dart';
+
+abstract interface class PhotoRepository
+    implements Repository<PhotoModel, String, PhotoDto> {
+  Future<List<PhotoModel>> findPhotosByJournalId(String journalId);
+  Future<List<PhotoModel>> findPhotosByDateRange({
+    required DateTime startDate,
+    required DateTime endDate,
+  });
+  Future<void> savePhoto(PhotoModel model);
+  Future<void> deletePhoto(String photoId);
+}

--- a/lib/photo/data/repository/photo_repository_impl.dart
+++ b/lib/photo/data/repository/photo_repository_impl.dart
@@ -1,0 +1,62 @@
+import 'package:photopin/photo/data/data_source/photo_data_source.dart';
+import 'package:photopin/photo/data/mapper/photo_mapper.dart';
+import 'package:photopin/photo/data/repository/photo_repository.dart';
+import 'package:photopin/photo/domain/model/photo_model.dart';
+
+class PhotoRepositoryImpl implements PhotoRepository {
+  final PhotoDataSource dataSource;
+
+  const PhotoRepositoryImpl({required this.dataSource});
+
+  @override
+  Future<void> deletePhoto(String photoId) async {
+    await dataSource.deletePhoto(photoId);
+  }
+
+  @override
+  Future<List<PhotoModel>> findAll() async {
+    return (await dataSource.findPhotos()).map((dto) => dto.toModel()).toList();
+  }
+
+  @override
+  Future<PhotoModel?> findByFilter(
+    bool Function(PhotoModel predicate) predicate,
+  ) async {
+    List<PhotoModel> photos = await findAll();
+
+    return photos.firstWhere(predicate);
+  }
+
+  @override
+  Future<PhotoModel?> findOne(String id) async {
+    return (await dataSource.findPhotoById(id)).toModel();
+  }
+
+  @override
+  Future<List<PhotoModel>> findPhotosByDateRange({
+    required DateTime startDate,
+    required DateTime endDate,
+  }) async {
+    List<PhotoModel> photos = await findAll();
+
+    return photos
+        .where(
+          (photo) =>
+              photo.dateTime.isAfter(startDate) &&
+              photo.dateTime.isBefore(endDate),
+        )
+        .toList();
+  }
+
+  @override
+  Future<List<PhotoModel>> findPhotosByJournalId(String journalId) async {
+    return (await dataSource.findPhotosByJournalId(
+      journalId,
+    )).map((dto) => dto.toModel()).toList();
+  }
+
+  @override
+  Future<void> savePhoto(PhotoModel model) async {
+    await dataSource.savePhoto(model.toDto());
+  }
+}

--- a/lib/photo/data/repository/photo_repository_impl.dart
+++ b/lib/photo/data/repository/photo_repository_impl.dart
@@ -19,15 +19,6 @@ class PhotoRepositoryImpl implements PhotoRepository {
   }
 
   @override
-  Future<PhotoModel?> findByFilter(
-    bool Function(PhotoModel predicate) predicate,
-  ) async {
-    List<PhotoModel> photos = await findAll();
-
-    return photos.firstWhere(predicate);
-  }
-
-  @override
   Future<PhotoModel?> findOne(String id) async {
     return (await dataSource.findPhotoById(id)).toModel();
   }

--- a/test/photo/data/repository/fake_photo_data_source.dart
+++ b/test/photo/data/repository/fake_photo_data_source.dart
@@ -1,0 +1,34 @@
+import 'package:mocktail/mocktail.dart';
+import 'package:photopin/photo/data/data_source/photo_data_source.dart';
+import 'package:photopin/photo/data/dto/photo_dto.dart';
+
+class FakePhotoDataSource extends Fake implements PhotoDataSource {
+  final List<PhotoDto> photos;
+
+  FakePhotoDataSource({required this.photos});
+
+  @override
+  Future<List<PhotoDto>> findPhotosByJournalId(String journalId) async {
+    return photos.where((photo) => photo.journalId == journalId).toList();
+  }
+
+  @override
+  Future<PhotoDto> findPhotoById(String id) async {
+    return photos.firstWhere((photo) => photo.id == id);
+  }
+
+  @override
+  Future<List<PhotoDto>> findPhotos() async {
+    return photos;
+  }
+
+  @override
+  Future<void> savePhoto(PhotoDto dto) async {
+    photos.add(dto);
+  }
+
+  @override
+  Future<void> deletePhoto(String photoId) async {
+    photos.removeWhere((photo) => photo.id == photoId);
+  }
+}

--- a/test/photo/data/repository/photo_repository_test.dart
+++ b/test/photo/data/repository/photo_repository_test.dart
@@ -24,7 +24,7 @@ void main() {
     final List<PhotoModel> photos = await repository.findAll();
 
     expect(photos.first, isA<PhotoModel>());
-    expect(photos.length, 4);
+    expect(photos.length, photoDtoFixtures.length);
   });
   test('findOne을 호출하면 id에 맞는 PhotoModel 형태로 반환해야한다.', () async {
     PhotoModel photo = (await repository.findOne('1'))!;
@@ -61,7 +61,7 @@ void main() {
     final List<PhotoModel> photos = await repository.findAll();
 
     expect(photos.first, isA<PhotoModel>());
-    expect(photos.length, 5);
+    expect(photos.length, photoDtoFixtures.length);
     expect(photos.any((photo) => photo.id == '5'), isTrue);
   });
   test('deletePhoto 호출하면 List<PhotoModel> 형태로 반환해야한다.', () async {
@@ -69,7 +69,7 @@ void main() {
     final List<PhotoModel> photos = await repository.findAll();
 
     expect(photos.first, isA<PhotoModel>());
-    expect(photos.length, 4);
+    expect(photos.length, photoDtoFixtures.length);
     expect(photos.any((photo) => photo.id == '5'), isFalse);
   });
 }

--- a/test/photo/data/repository/photo_repository_test.dart
+++ b/test/photo/data/repository/photo_repository_test.dart
@@ -5,6 +5,7 @@ import 'package:photopin/photo/data/repository/photo_repository_impl.dart';
 import 'package:photopin/photo/domain/model/photo_model.dart';
 
 import '../../fixtures/photo_dto_fixtures.dart';
+import '../../fixtures/photo_model_fixtures.dart';
 import 'fake_photo_data_source.dart';
 
 void main() {

--- a/test/photo/data/repository/photo_repository_test.dart
+++ b/test/photo/data/repository/photo_repository_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:photopin/photo/data/data_source/photo_data_source.dart';
+import 'package:photopin/photo/data/repository/photo_repository.dart';
+import 'package:photopin/photo/data/repository/photo_repository_impl.dart';
+import 'package:photopin/photo/domain/model/photo_model.dart';
+
+import '../../fixtures/photo_dto_fixtures.dart';
+import 'fake_photo_data_source.dart';
+
+void main() {
+  late PhotoRepository repository;
+  const String journalId = 'journal1';
+  final PhotoDataSource dataSource = FakePhotoDataSource(
+    photos: photoDtoFixtures,
+  );
+  final DateTime endDate = DateTime(2025, 05, 10);
+  final DateTime startDate = DateTime(2025, 05, 08);
+
+  setUpAll(() {
+    repository = PhotoRepositoryImpl(dataSource: dataSource);
+  });
+
+  test('findAll을 호출하면 List<PhotoModel> 형태로 반환해야한다.', () async {
+    final List<PhotoModel> photos = await repository.findAll();
+
+    expect(photos.first, isA<PhotoModel>());
+    expect(photos.length, 4);
+  });
+  test('findOne을 호출하면 id에 맞는 PhotoModel 형태로 반환해야한다.', () async {
+    PhotoModel photo = (await repository.findOne('1'))!;
+
+    expect(photo, isA<PhotoModel>());
+    expect(photo.id, '1');
+  });
+  test(
+    'findPhotosByJournalId를 호출하면 journalId에 맞는 PhotoModel 형태로 반환해야한다.',
+    () async {
+      final List<PhotoModel> photos = await repository.findPhotosByJournalId(
+        journalId,
+      );
+
+      expect(photos.first, isA<PhotoModel>());
+      expect(photos.first.journalId, journalId);
+    },
+  );
+  test(
+    'findPhotosByDateRange 호출하면 startDate 와 endDate에 맞는 List<PhotoModel> 형태로 반환해야한다.',
+    () async {
+      final List<PhotoModel> photos = await repository.findPhotosByDateRange(
+        startDate: startDate,
+        endDate: endDate,
+      );
+      expect(photos.first, isA<PhotoModel>());
+      expect(photos.length, 2);
+      expect(photos.first.dateTime.isBefore(endDate), isTrue);
+      expect(photos.last.dateTime.isAfter(startDate), isTrue);
+    },
+  );
+  test('savePhoto 호출하면 List<PhotoModel>에 값이 제대로 저장되어야한다.', () async {
+    await repository.savePhoto(photoModelFixture);
+    final List<PhotoModel> photos = await repository.findAll();
+
+    expect(photos.first, isA<PhotoModel>());
+    expect(photos.length, 5);
+    expect(photos.any((photo) => photo.id == '5'), isTrue);
+  });
+  test('deletePhoto 호출하면 List<PhotoModel> 형태로 반환해야한다.', () async {
+    await repository.deletePhoto('5');
+    final List<PhotoModel> photos = await repository.findAll();
+
+    expect(photos.first, isA<PhotoModel>());
+    expect(photos.length, 4);
+    expect(photos.any((photo) => photo.id == '5'), isFalse);
+  });
+}

--- a/test/photo/fixtures/photo_dto_fixtures.dart
+++ b/test/photo/fixtures/photo_dto_fixtures.dart
@@ -1,16 +1,4 @@
-import 'package:photopin/location/domain/model/location_model.dart';
 import 'package:photopin/photo/data/dto/photo_dto.dart';
-import 'package:photopin/photo/domain/model/photo_model.dart';
-
-final PhotoModel photoModelFixture = PhotoModel(
-  id: '5',
-  comment: 'test5',
-  dateTime: DateTime.now(),
-  imageUrl: '',
-  journalId: 'journal2',
-  location: const LocationModel(latitude: 0, longitude: 0),
-  name: 'test Photo5',
-);
 
 final List<PhotoDto> photoDtoFixtures = [
   PhotoDto(

--- a/test/photo/fixtures/photo_dto_fixtures.dart
+++ b/test/photo/fixtures/photo_dto_fixtures.dart
@@ -1,0 +1,56 @@
+import 'package:photopin/location/domain/model/location_model.dart';
+import 'package:photopin/photo/data/dto/photo_dto.dart';
+import 'package:photopin/photo/domain/model/photo_model.dart';
+
+final PhotoModel photoModelFixture = PhotoModel(
+  id: '5',
+  comment: 'test5',
+  dateTime: DateTime.now(),
+  imageUrl: '',
+  journalId: 'journal2',
+  location: const LocationModel(latitude: 0, longitude: 0),
+  name: 'test Photo5',
+);
+
+final List<PhotoDto> photoDtoFixtures = [
+  PhotoDto(
+    id: '1',
+    comment: 'test1',
+    dateTime: DateTime.now(),
+    imageUrl: '',
+    journalId: 'journal1',
+    latitude: 12.343,
+    longitude: 43.12,
+    name: 'test Photo1',
+  ),
+  PhotoDto(
+    id: '2',
+    comment: 'test2',
+    dateTime: DateTime(2025, 05, 09),
+    imageUrl: '',
+    journalId: 'journal1',
+    latitude: 0.1212,
+    longitude: 0.435,
+    name: 'test Photo2',
+  ),
+  PhotoDto(
+    id: '3',
+    comment: 'test3',
+    dateTime: DateTime(2025, 05, 11),
+    imageUrl: '',
+    journalId: 'journal1',
+    latitude: 10.23,
+    longitude: 0.555,
+    name: 'test Photo3',
+  ),
+  PhotoDto(
+    id: '4',
+    comment: 'test4',
+    dateTime: DateTime(2025, 05, 15),
+    imageUrl: '',
+    journalId: 'journal2',
+    latitude: 0.1,
+    longitude: 0.23,
+    name: 'test Photo4',
+  ),
+];

--- a/test/photo/fixtures/photo_model_fixtures.dart
+++ b/test/photo/fixtures/photo_model_fixtures.dart
@@ -1,0 +1,12 @@
+import 'package:photopin/location/domain/model/location_model.dart';
+import 'package:photopin/photo/domain/model/photo_model.dart';
+
+final PhotoModel photoModelFixture = PhotoModel(
+  id: '5',
+  comment: 'test5',
+  dateTime: DateTime.now(),
+  imageUrl: '',
+  journalId: 'journal2',
+  location: const LocationModel(latitude: 0, longitude: 0),
+  name: 'test Photo5',
+);


### PR DESCRIPTION
## 🔍 개요 (Summary)

- photo repository 생성
- photo data source & repository di에 추가

---

## ✅ 변경 사항 (Changes)

- photo repository 생성
    - photo_repostiroy.dart interface 추가
    - photo_repository_imp.dart interface 구현체 추가
    - photo repository test 코드 추가
- photo data source & repository di에 추가

---

## 🔗 관련 이슈 (Related Issues)

- #112 

---

## 🧪 테스트 (Test)

- [x] findAll을 호출하면 List<PhotoModel> 형태로 반환해야한다.
- [x] findOne을 호출하면 id에 맞는 PhotoModel 형태로 반환해야한다.
- [x] findPhotosByJournalId를 호출하면 journalId에 맞는 PhotoModel 형태로 반환해야한다.
- [x] findPhotosByDateRange 호출하면 startDate 와 endDate에 맞는 List<PhotoModel> 형태로 반환해야한다.
- [x] savePhoto 호출하면 List<PhotoModel>에 값이 제대로 저장되어야한다.
- [x] deletePhoto 호출하면 List<PhotoModel> 형태로 반환해야한다.

---

## 👀 리뷰어 체크리스트 (For Reviewer)

- [ ] 기능이 명세에 맞게 동작하는지 확인
- [ ] 불필요한 코드/주석이 없는지 확인
- [ ] 테스트가 적절히 작성되었는지 확인
