### PR TITLE
#122 feat auth data source repository

### DIFF
--- a/lib/auth/data/data_source/auth_data_source.dart
+++ b/lib/auth/data/data_source/auth_data_source.dart
@@ -1,0 +1,7 @@
+import 'package:photopin/user/data/dto/user_dto.dart';
+
+abstract interface class AuthDataSource {
+  Future<void> login();
+  Future<UserDto> findCurrentUser();
+  Future<String> findCurrentUserId();
+}

--- a/lib/auth/data/data_source/auth_data_source_impl.dart
+++ b/lib/auth/data/data_source/auth_data_source_impl.dart
@@ -1,0 +1,53 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:photopin/auth/data/data_source/auth_data_source.dart';
+import 'package:photopin/core/errors/firestore_error.dart';
+import 'package:photopin/user/data/dto/user_dto.dart';
+import 'package:photopin/user/data/mapper/user_mapper.dart';
+
+class AuthDataSourceImpl implements AuthDataSource {
+  final FirebaseAuth auth;
+
+  const AuthDataSourceImpl({required this.auth});
+
+  @override
+  Future<UserDto> findCurrentUser() async {
+    User? user = auth.currentUser;
+
+    if (user != null) {
+      return user.toDto();
+    }
+
+    throw FirestoreError.notFoundError;
+  }
+
+  @override
+  Future<String> findCurrentUserId() async {
+    User? user = auth.currentUser;
+
+    if (user != null) {
+      return user.uid;
+    }
+
+    throw FirestoreError.notFoundError;
+  }
+
+  @override
+  Future<void> login() async {
+    // Trigger the authentication flow
+    final GoogleSignInAccount? googleUser = await GoogleSignIn().signIn();
+
+    // Obtain the auth details from the request
+    final GoogleSignInAuthentication? googleAuth =
+        await googleUser?.authentication;
+
+    // Create a new credential
+    final credential = GoogleAuthProvider.credential(
+      accessToken: googleAuth?.accessToken,
+      idToken: googleAuth?.idToken,
+    );
+
+    // Once signed in, return the UserCredential
+    await auth.signInWithCredential(credential);
+  }
+}

--- a/lib/auth/data/data_source/auth_data_source_impl.dart
+++ b/lib/auth/data/data_source/auth_data_source_impl.dart
@@ -42,13 +42,13 @@ class AuthDataSourceImpl implements AuthDataSource {
     }
 
     // Obtain the auth details from the request
-    final GoogleSignInAuthentication? googleAuth =
+    final GoogleSignInAuthentication googleAuth =
         await googleUser.authentication;
 
     // Create a new credential
     final credential = GoogleAuthProvider.credential(
-      accessToken: googleAuth?.accessToken,
-      idToken: googleAuth?.idToken,
+      accessToken: googleAuth.accessToken,
+      idToken: googleAuth.idToken,
     );
 
     // Once signed in, return the UserCredential

--- a/lib/auth/data/data_source/auth_data_source_impl.dart
+++ b/lib/auth/data/data_source/auth_data_source_impl.dart
@@ -36,9 +36,9 @@ class AuthDataSourceImpl implements AuthDataSource {
   Future<void> login() async {
     // Trigger the authentication flow
     final GoogleSignInAccount? googleUser = await GoogleSignIn().signIn();
+
     if (googleUser == null) {
-      // Handle the case where the user cancels the sign-in process
-      throw FirestoreError.authenticationCanceledError;
+      throw FirestoreError.notFoundError;
     }
 
     // Obtain the auth details from the request

--- a/lib/auth/data/data_source/auth_data_source_impl.dart
+++ b/lib/auth/data/data_source/auth_data_source_impl.dart
@@ -36,10 +36,14 @@ class AuthDataSourceImpl implements AuthDataSource {
   Future<void> login() async {
     // Trigger the authentication flow
     final GoogleSignInAccount? googleUser = await GoogleSignIn().signIn();
+    if (googleUser == null) {
+      // Handle the case where the user cancels the sign-in process
+      throw FirestoreError.authenticationCanceledError;
+    }
 
     // Obtain the auth details from the request
     final GoogleSignInAuthentication? googleAuth =
-        await googleUser?.authentication;
+        await googleUser.authentication;
 
     // Create a new credential
     final credential = GoogleAuthProvider.credential(

--- a/lib/auth/data/repository/auth_repository.dart
+++ b/lib/auth/data/repository/auth_repository.dart
@@ -1,0 +1,7 @@
+import 'package:photopin/user/domain/model/user_model.dart';
+
+abstract interface class AuthRepository {
+  Future<void> login();
+  Future<UserModel> findCurrentUser();
+  Future<String> findCurrentUserId();
+}

--- a/lib/auth/data/repository/auth_repository_impl.dart
+++ b/lib/auth/data/repository/auth_repository_impl.dart
@@ -1,0 +1,25 @@
+import 'package:photopin/auth/data/data_source/auth_data_source.dart';
+import 'package:photopin/auth/data/repository/auth_repository.dart';
+import 'package:photopin/user/data/mapper/user_mapper.dart';
+import 'package:photopin/user/domain/model/user_model.dart';
+
+class AuthRepositoryImpl implements AuthRepository {
+  final AuthDataSource dataSource;
+
+  const AuthRepositoryImpl({required this.dataSource});
+
+  @override
+  Future<UserModel> findCurrentUser() async {
+    return (await dataSource.findCurrentUser()).toModel();
+  }
+
+  @override
+  Future<String> findCurrentUserId() async {
+    return await dataSource.findCurrentUserId();
+  }
+
+  @override
+  Future<void> login() async {
+    await dataSource.login();
+  }
+}

--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -1,4 +1,9 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:get_it/get_it.dart';
+import 'package:photopin/auth/data/data_source/auth_data_source.dart';
+import 'package:photopin/auth/data/data_source/auth_data_source_impl.dart';
+import 'package:photopin/auth/data/repository/auth_repository.dart';
+import 'package:photopin/auth/data/repository/auth_repository_impl.dart';
 import 'package:photopin/core/firebase/firestore_setup.dart';
 import 'package:photopin/photo/data/data_source/photo_data_source.dart';
 import 'package:photopin/photo/data/data_source/photo_data_source_impl.dart';
@@ -25,6 +30,13 @@ void di() {
     (userId, _) => PhotoDataSourceImpl(
       photoStore: getIt<FirestoreSetup>().photoFirestore(userId),
     ),
+  );
+  getIt.registerLazySingleton(() => FirebaseAuth.instance);
+  getIt.registerLazySingleton<AuthDataSource>(
+    () => AuthDataSourceImpl(auth: getIt()),
+  );
+  getIt.registerLazySingleton<AuthRepository>(
+    () => AuthRepositoryImpl(dataSource: getIt()),
   );
   getIt.registerLazySingleton<PhotoRepository>(
     () => PhotoRepositoryImpl(dataSource: getIt()),

--- a/lib/user/data/mapper/user_mapper.dart
+++ b/lib/user/data/mapper/user_mapper.dart
@@ -1,3 +1,5 @@
+import 'package:firebase_auth/firebase_auth.dart';
+
 import '../../domain/model/user_model.dart';
 import '../dto/user_dto.dart';
 
@@ -8,6 +10,17 @@ extension UserMapper on UserDto {
       email: email ?? 'N/A',
       profileImg: profileImg ?? 'N/A',
       displayName: displayName ?? 'N/A',
+    );
+  }
+}
+
+extension AuthMapper on User {
+  UserDto toDto() {
+    return UserDto(
+      id: uid,
+      email: email,
+      profileImg: photoURL,
+      displayName: displayName,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,7 @@ dependencies:
   get_it: ^8.0.3
   derry: ^1.5.0
   mocktail: ^1.0.4
+  google_sign_in: ^6.3.0
 
 dev_dependencies:
   flutter_test:

--- a/test/auth/data/data_source/auth_data_source_test.dart
+++ b/test/auth/data/data_source/auth_data_source_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:photopin/auth/data/data_source/auth_data_source.dart';
+import 'package:photopin/core/errors/firestore_error.dart';
+import 'package:photopin/user/data/dto/user_dto.dart';
+
+import '../../fixtures/auth_data_fixtures.dart';
+import 'fake_auth_data_source.dart';
+
+void main() {
+  late AuthDataSource dataSource;
+
+  setUpAll(() {
+    dataSource = FakeAuthDataSource();
+  });
+
+  test('login() 전 상태에서 findCurrentUser() 호출 시 notFoundError 가 발생되어야 한다.', () {
+    expect(
+      () async => await dataSource.findCurrentUser(),
+      throwsA(isA<FirestoreError>()),
+    );
+  });
+  test('login() 전 상태에서 findCurrentUserId() 호출 시 notFoundError 가 발생되어야 한다.', () {
+    expect(
+      () async => await dataSource.findCurrentUserId(),
+      throwsA(isA<FirestoreError>()),
+    );
+  });
+  test('login() 호출 시 유저 목록에 값이 추가 되어야한다.', () async {
+    await dataSource.login();
+    final UserDto dto = await dataSource.findCurrentUser();
+
+    expect(dto, authFixture);
+  });
+  test('login() 후 활성화된 유저를 가져올 수 있어야한다.', () async {
+    await dataSource.login();
+    final UserDto dto = await dataSource.findCurrentUser();
+
+    expect(dto, authFixture);
+  });
+  test('login() 후 활성화된 유저의 id 값을 가져올 수 있어야한다.', () async {
+    await dataSource.login();
+    final String dtoId = await dataSource.findCurrentUserId();
+
+    expect(dtoId, authFixture.id);
+  });
+}

--- a/test/auth/data/data_source/fake_auth_data_source.dart
+++ b/test/auth/data/data_source/fake_auth_data_source.dart
@@ -1,0 +1,29 @@
+import 'package:mocktail/mocktail.dart';
+import 'package:photopin/auth/data/data_source/auth_data_source.dart';
+import 'package:photopin/core/errors/firestore_error.dart';
+import 'package:photopin/user/data/dto/user_dto.dart';
+
+import '../../fixtures/auth_data_fixtures.dart';
+
+class FakeAuthDataSource extends Fake implements AuthDataSource {
+  @override
+  Future<UserDto> findCurrentUser() async {
+    if (authDataFixtures.isEmpty) {
+      throw FirestoreError.notFoundError;
+    }
+    return authDataFixtures.first;
+  }
+
+  @override
+  Future<String> findCurrentUserId() async {
+    if (authDataFixtures.isEmpty) {
+      throw FirestoreError.notFoundError;
+    }
+    return 'testUserId';
+  }
+
+  @override
+  Future<void> login() async {
+    authDataFixtures.add(authFixture);
+  }
+}

--- a/test/auth/data/repository/auth_repository_test.dart
+++ b/test/auth/data/repository/auth_repository_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:photopin/auth/data/data_source/auth_data_source.dart';
+import 'package:photopin/auth/data/repository/auth_repository.dart';
+import 'package:photopin/auth/data/repository/auth_repository_impl.dart';
+import 'package:photopin/core/errors/firestore_error.dart';
+import 'package:photopin/user/data/mapper/user_mapper.dart';
+import 'package:photopin/user/domain/model/user_model.dart';
+
+import '../../fixtures/auth_data_fixtures.dart';
+import '../data_source/fake_auth_data_source.dart';
+
+void main() {
+  late AuthDataSource dataSource;
+  late AuthRepository repository;
+
+  setUpAll(() {
+    dataSource = FakeAuthDataSource();
+    repository = AuthRepositoryImpl(dataSource: dataSource);
+  });
+
+  test('login() 전 상태에서 findCurrentUser() 호출 시 notFoundError 가 발생되어야 한다.', () {
+    expect(
+      () async => await repository.findCurrentUser(),
+      throwsA(isA<FirestoreError>()),
+    );
+  });
+  test('login() 전 상태에서 findCurrentUserId() 호출 시 notFoundError 가 발생되어야 한다.', () {
+    expect(
+      () async => await repository.findCurrentUserId(),
+      throwsA(isA<FirestoreError>()),
+    );
+  });
+  test('login() 호출 시 유저 목록에 값이 추가 되어야한다.', () async {
+    await repository.login();
+    final UserModel model = await repository.findCurrentUser();
+
+    expect(model, authFixture.toModel());
+  });
+  test('login() 후 활성화된 유저를 가져올 수 있어야한다.', () async {
+    await repository.login();
+    final UserModel model = await repository.findCurrentUser();
+
+    expect(model, authFixture.toModel());
+  });
+  test('login() 후 활성화된 유저의 id 값을 가져올 수 있어야한다.', () async {
+    await repository.login();
+    final String modelId = await repository.findCurrentUserId();
+
+    expect(modelId, authFixture.id);
+  });
+}

--- a/test/auth/fixtures/auth_data_fixtures.dart
+++ b/test/auth/fixtures/auth_data_fixtures.dart
@@ -1,0 +1,9 @@
+import 'package:photopin/user/data/dto/user_dto.dart';
+
+final List<UserDto> authDataFixtures = [];
+const UserDto authFixture = UserDto(
+  id: 'testUserId',
+  email: 'yujehwan808@gmail.com',
+  profileImg: '',
+  displayName: '유제환',
+);


### PR DESCRIPTION
## 🔍 개요 (Summary)

- auth data source & repository create

---

## ✅ 변경 사항 (Changes)

- auth data source & repository create
    - auth data source interface & impl create
    - auth repository interface & impl create
    - auth test code 작성

---

## 🔗 관련 이슈 (Related Issues)

- #122

---

## 🧪 테스트 (Test)

- [x] login() 전 상태에서 findCurrentUser() 호출 시 notFoundError 가 발생되어야 한다.
- [x] login() 전 상태에서 findCurrentUserId() 호출 시 notFoundError 가 발생되어야 한다.
- [x] login() 호출 시 유저 목록에 값이 추가 되어야한다.
- [x] login() 후 활성화된 유저를 가져올 수 있어야한다.
- [x] login() 후 활성화된 유저의 id 값을 가져올 수 있어야한다.



## 📝 참고 사항 (Notes)

- 리뷰어가 이해하는 데 도움이 될 만한 기타 정보
- 논의가 필요한 부분이나 리뷰 요청 포인트 등

---

## 👀 리뷰어 체크리스트 (For Reviewer)

- [ ] 기능이 명세에 맞게 동작하는지 확인
- [ ] 불필요한 코드/주석이 없는지 확인
- [ ] 테스트가 적절히 작성되었는지 확인
