### PR TITLE
#129 feat auth screen create

### DIFF
--- a/lib/auth/data/data_source/auth_data_source.dart
+++ b/lib/auth/data/data_source/auth_data_source.dart
@@ -4,4 +4,5 @@ abstract interface class AuthDataSource {
   Future<void> login();
   Future<UserDto> findCurrentUser();
   Future<String> findCurrentUserId();
+  Future<void> logout();
 }

--- a/lib/auth/data/data_source/auth_data_source_impl.dart
+++ b/lib/auth/data/data_source/auth_data_source_impl.dart
@@ -54,4 +54,9 @@ class AuthDataSourceImpl implements AuthDataSource {
     // Once signed in, return the UserCredential
     await auth.signInWithCredential(credential);
   }
+
+  @override
+  Future<void> logout() async {
+    await auth.signOut();
+  }
 }

--- a/lib/auth/data/repository/auth_repository.dart
+++ b/lib/auth/data/repository/auth_repository.dart
@@ -2,6 +2,7 @@ import 'package:photopin/user/domain/model/user_model.dart';
 
 abstract interface class AuthRepository {
   Future<void> login();
+  Future<void> logout();
   Future<UserModel> findCurrentUser();
   Future<String> findCurrentUserId();
 }

--- a/lib/auth/data/repository/auth_repository_impl.dart
+++ b/lib/auth/data/repository/auth_repository_impl.dart
@@ -22,4 +22,9 @@ class AuthRepositoryImpl implements AuthRepository {
   Future<void> login() async {
     await dataSource.login();
   }
+
+  @override
+  Future<void> logout() async {
+    await dataSource.logout();
+  }
 }

--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -9,6 +9,7 @@ import 'package:photopin/photo/data/data_source/photo_data_source.dart';
 import 'package:photopin/photo/data/data_source/photo_data_source_impl.dart';
 import 'package:photopin/photo/data/repository/photo_repository.dart';
 import 'package:photopin/photo/data/repository/photo_repository_impl.dart';
+import 'package:photopin/presentation/screen/auth/auth_view_model.dart';
 import 'package:photopin/user/data/data_source/user_data_source.dart';
 import 'package:photopin/user/data/data_source/user_data_source_impl.dart';
 import 'package:photopin/user/data/repository/user_repository.dart';
@@ -17,13 +18,15 @@ import 'package:photopin/user/data/repository/user_repository_impl.dart';
 final getIt = GetIt.instance;
 
 void di() {
+  getIt.registerLazySingleton(() => FirebaseAuth.instance);
+
+  getIt.registerLazySingleton<FirestoreSetup>(() => FirestoreSetup());
+
   getIt.registerSingleton<UserDataSource>(
     UserDataSourceImpl(userStore: getIt.get<FirestoreSetup>().userFirestore()),
   );
 
   getIt.registerSingleton<UserRepository>(UserRepositoryImpl(getIt()));
-
-  getIt.registerLazySingleton<FirestoreSetup>(() => FirestoreSetup());
 
   // userId 마다 firestore에서 받아오는 photo collection 이 달라져야함으로 싱글톤이 의미가 없음.
   getIt.registerFactoryParam<PhotoDataSource, String, void>(
@@ -31,7 +34,7 @@ void di() {
       photoStore: getIt<FirestoreSetup>().photoFirestore(userId),
     ),
   );
-  getIt.registerLazySingleton(() => FirebaseAuth.instance);
+
   getIt.registerLazySingleton<AuthDataSource>(
     () => AuthDataSourceImpl(auth: getIt()),
   );
@@ -41,4 +44,5 @@ void di() {
   getIt.registerLazySingleton<PhotoRepository>(
     () => PhotoRepositoryImpl(dataSource: getIt()),
   );
+  getIt.registerFactory<AuthViewModel>(() => AuthViewModel(getIt()));
 }

--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -4,6 +4,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
+import 'package:photopin/core/di/di_setup.dart';
 
 import 'firebase_options.dart';
 
@@ -18,6 +19,8 @@ void main() async {
     FirebaseFirestore.instance.useFirestoreEmulator('localhost', 8080);
     await FirebaseAuth.instance.useAuthEmulator('localhost', 9099);
   }
+
+  di();
 
   runApp(const MyApp());
 }

--- a/lib/presentation/screen/auth/auth_action.dart
+++ b/lib/presentation/screen/auth/auth_action.dart
@@ -1,0 +1,11 @@
+sealed class AuthAction {
+  factory AuthAction.login() = Login;
+  factory AuthAction.logout() = Logout;
+  factory AuthAction.onClick() = OnClick;
+}
+
+class Login implements AuthAction {}
+
+class Logout implements AuthAction {}
+
+class OnClick implements AuthAction {}

--- a/lib/presentation/screen/auth/auth_screen.dart
+++ b/lib/presentation/screen/auth/auth_screen.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:photopin/presentation/screen/auth/auth_action.dart';
+import 'package:photopin/presentation/screen/auth/auth_state.dart';
+
+class AuthScreen extends StatelessWidget {
+  final AuthState state;
+  final void Function(AuthAction) onAction;
+  const AuthScreen({super.key, required this.state, required this.onAction});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SizedBox(
+        width: double.infinity,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            !state.isLoading
+                ? ElevatedButton(
+                  child: const Text('login'),
+                  onPressed: () {
+                    onAction(AuthAction.login());
+                    onAction(AuthAction.onClick());
+                  },
+                )
+                : const CircularProgressIndicator(),
+            Text(state.email),
+            ElevatedButton(
+              child: const Text('logout'),
+              onPressed: () async {
+                onAction(AuthAction.logout());
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/screen/auth/auth_screen_root.dart
+++ b/lib/presentation/screen/auth/auth_screen_root.dart
@@ -48,10 +48,13 @@ class _AuthScreenRootState extends State<AuthScreenRoot> {
         return AuthScreen(
           state: widget.authViewModel.state,
           onAction: (action) {
-            if (action case OnClick()) {
-              // TODO : 화면 이동 로직 추가
-            } else {
-              widget.authViewModel.action(action);
+            switch (action) {
+              case Login():
+                widget.authViewModel.action(action);
+              case Logout():
+                widget.authViewModel.action(action);
+              case OnClick():
+              //TODO : 화면 이동 로직 추가
             }
           },
         );

--- a/lib/presentation/screen/auth/auth_screen_root.dart
+++ b/lib/presentation/screen/auth/auth_screen_root.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:photopin/core/styles/app_color.dart';
+import 'package:photopin/presentation/screen/auth/auth_action.dart';
+import 'package:photopin/presentation/screen/auth/auth_screen.dart';
+import 'package:photopin/presentation/screen/auth/auth_view_model.dart';
+
+class AuthScreenRoot extends StatefulWidget {
+  final AuthViewModel authViewModel;
+  const AuthScreenRoot({super.key, required this.authViewModel});
+
+  @override
+  State<AuthScreenRoot> createState() => _AuthScreenRootState();
+}
+
+class _AuthScreenRootState extends State<AuthScreenRoot> {
+  StreamSubscription? _errorSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _errorSubscription = widget.authViewModel.errorStream.listen((error) {
+      if (mounted) {
+        if (error != null) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('${error.toString}'),
+              backgroundColor: AppColors.warningBackground, // 필요에 따라 색상 지정
+            ),
+          );
+        }
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _errorSubscription?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: widget.authViewModel,
+      builder: (context, _) {
+        return AuthScreen(
+          state: widget.authViewModel.state,
+          onAction: (action) {
+            if (action case OnClick()) {
+              // TODO : 화면 이동 로직 추가
+            } else {
+              widget.authViewModel.action(action);
+            }
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/presentation/screen/auth/auth_screen_root.dart
+++ b/lib/presentation/screen/auth/auth_screen_root.dart
@@ -25,7 +25,7 @@ class _AuthScreenRootState extends State<AuthScreenRoot> {
         if (error != null) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
-              content: Text('${error.toString}'),
+              content: Text(error.toString()),
               backgroundColor: AppColors.warningBackground, // 필요에 따라 색상 지정
             ),
           );

--- a/lib/presentation/screen/auth/auth_state.dart
+++ b/lib/presentation/screen/auth/auth_state.dart
@@ -1,0 +1,13 @@
+class AuthState {
+  final bool isLoading;
+  final String email;
+
+  const AuthState({this.isLoading = false, this.email = ''});
+
+  AuthState copyWith({bool? isLoading, String? email}) {
+    return AuthState(
+      isLoading: isLoading ?? this.isLoading,
+      email: email ?? this.email,
+    );
+  }
+}

--- a/lib/presentation/screen/auth/auth_view_model.dart
+++ b/lib/presentation/screen/auth/auth_view_model.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:photopin/auth/data/repository/auth_repository.dart';
+import 'package:photopin/presentation/screen/auth/auth_action.dart';
+import 'package:photopin/presentation/screen/auth/auth_state.dart';
+
+class AuthViewModel with ChangeNotifier {
+  final AuthRepository _authRepository;
+  AuthState _state = const AuthState();
+  final _eventController = StreamController<Exception?>();
+
+  Stream<Exception?> get errorStream => _eventController.stream;
+
+  @override
+  void dispose() {
+    _eventController.close();
+    super.dispose();
+  }
+
+  AuthState get state => _state;
+
+  AuthViewModel(this._authRepository);
+
+  Future<void> action(AuthAction action) async {
+    switch (action) {
+      case Login():
+        await _login();
+      case OnClick():
+        break;
+      case Logout():
+        await _logout();
+    }
+  }
+
+  Future<void> _login() async {
+    try {
+      _state = state.copyWith(isLoading: true);
+      notifyListeners();
+
+      await _authRepository.login();
+      _state = state.copyWith(
+        email: (await _authRepository.findCurrentUser()).email,
+      );
+    } on Exception catch (e) {
+      _addError(e);
+    } finally {
+      _state = state.copyWith(isLoading: false);
+      notifyListeners();
+    }
+  }
+
+  Future<void> _logout() async {
+    try {
+      _state = state.copyWith(isLoading: true);
+      notifyListeners();
+
+      await _authRepository.logout();
+      _state = state.copyWith(email: '');
+    } on Exception catch (e) {
+      _addError(e);
+    } finally {
+      _state = state.copyWith(isLoading: false);
+      notifyListeners();
+    }
+  }
+
+  void _addError(Exception e) {
+    _eventController.add(e);
+  }
+}

--- a/test/auth/data/data_source/fake_auth_data_source.dart
+++ b/test/auth/data/data_source/fake_auth_data_source.dart
@@ -26,4 +26,9 @@ class FakeAuthDataSource extends Fake implements AuthDataSource {
   Future<void> login() async {
     authDataFixtures.add(authFixture);
   }
+
+  @override
+  Future<void> logout() async {
+    authDataFixtures.remove(authFixture);
+  }
 }

--- a/test/presentation/screen/auth/auth_view_model.dart
+++ b/test/presentation/screen/auth/auth_view_model.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:photopin/auth/data/data_source/auth_data_source.dart';
+import 'package:photopin/auth/data/repository/auth_repository.dart';
+import 'package:photopin/auth/data/repository/auth_repository_impl.dart';
+import 'package:photopin/presentation/screen/auth/auth_action.dart';
+import 'package:photopin/presentation/screen/auth/auth_state.dart';
+import 'package:photopin/presentation/screen/auth/auth_view_model.dart';
+import 'package:photopin/user/data/mapper/user_mapper.dart';
+
+import '../../../auth/data/data_source/fake_auth_data_source.dart';
+import '../../../auth/fixtures/auth_data_fixtures.dart';
+
+void main() {
+  late AuthDataSource dataSource;
+  late AuthRepository repository;
+  late AuthViewModel viewModel;
+
+  setUpAll(() {
+    dataSource = FakeAuthDataSource();
+    repository = AuthRepositoryImpl(dataSource: dataSource);
+    viewModel = AuthViewModel(repository);
+  });
+
+  test('뷰모델의 초기 상태(state)는 isLoading이 false이고 email이 비어 있어야 한다.', () {
+    expect(viewModel.state, isA<AuthState>());
+    expect(viewModel.state.isLoading, false);
+    expect(viewModel.state.email, '');
+  });
+  group('action() : ', () {
+    test('action(AuthAction.login()) 은 login() 액션을 트리거 해야한다.', () async {
+      await viewModel.action(AuthAction.login());
+
+      expect(viewModel.state.email, authFixture.toModel().email);
+    });
+    test('action(AuthAction.logout()) 은 logout() 액션을 트리거 해야한다.', () async {
+      await viewModel.action(AuthAction.logout());
+
+      expect(viewModel.state.email, '');
+    });
+  });
+}


### PR DESCRIPTION
## 🔍 개요 (Summary)

- 로그인 화면 만들기
- logout 로직 추가
- main_dev 에 di() 실행 코드 추가

---

## ✅ 변경 사항 (Changes)

- 로그인 화면 만들기
    - auth action
    - auth state
    - auth view model
    - auth screen root
    - auth screen
- logout 로직 추가
    - auth data source interface & impl 
    - auth repository interface & impl
    - logout add
- main_dev 에 di() 실행 코드 추가

---

## 📸 스크린샷 (Screenshots, 선택사항)

![image](https://github.com/user-attachments/assets/c8792c59-2ed8-4fa6-ad91-ab664414aac7)


---
## 🔗 관련 이슈 (Related Issues)

- #129 

---

## 🧪 테스트 (Test)

- [ ]

## 📝 참고 사항 (Notes)

- 리뷰어가 이해하는 데 도움이 될 만한 기타 정보
- 논의가 필요한 부분이나 리뷰 요청 포인트 등

---

## 👀 리뷰어 체크리스트 (For Reviewer)

- [ ] 기능이 명세에 맞게 동작하는지 확인
- [ ] 불필요한 코드/주석이 없는지 확인
- [ ] 테스트가 적절히 작성되었는지 확인
