### PR TITLE
#157 feat home screen modify

### DIFF
--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -54,8 +54,18 @@ void di() {
     () => AuthRepositoryImpl(dataSource: getIt()),
   );
 
-  getIt.registerFactory<HomeViewModel>(
-    () => HomeViewModel(getCurrentUserUseCase: getIt<GetCurrentUserUseCase>()),
+  // getIt.registerFactory<HomeViewModel>(
+  //   () => HomeViewModel(
+  //     getCurrentUserUseCase: getIt<GetCurrentUserUseCase>(),
+  //     getJournalListUseCase: getIt<GetJournalListUseCase>(),
+  //   ),
+  // );
+
+  getIt.registerFactoryParam<HomeViewModel, String, void>(
+    (userId, _) => HomeViewModel(
+      getCurrentUserUseCase: getIt<GetCurrentUserUseCase>(),
+      getJournalListUseCase: getIt<GetJournalListUseCase>(param1: userId),
+    ),
   );
 
   getIt.registerFactoryParam<GetJournalListUseCase, String, void>(

--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -59,7 +59,10 @@ final appRouter = GoRouter(
             GoRoute(
               path: Routes.home,
               builder: (context, state) {
-                return HomeScreenRoot(viewModel: getIt<HomeViewModel>());
+                final String userId = getIt<FirebaseAuth>().currentUser!.uid;
+                return HomeScreenRoot(
+                  viewModel: getIt<HomeViewModel>(param1: userId),
+                );
               },
             ),
           ],

--- a/lib/presentation/screen/home/home_action.dart
+++ b/lib/presentation/screen/home/home_action.dart
@@ -4,7 +4,6 @@ sealed class HomeAction {
   factory HomeAction.shareClick() = ShareClick;
   factory HomeAction.recentActivityClick() = RecentActivityClick;
   factory HomeAction.seeAllClick() = SeeAllClick;
-  factory HomeAction.viewAllClick() = ViewAllClick;
   factory HomeAction.myJounalClick(String id) = MyJounalClick;
   factory HomeAction.findUser() = FindUser;
   factory HomeAction.findJounals() = FindJounals;
@@ -19,8 +18,6 @@ class ShareClick implements HomeAction {}
 class RecentActivityClick implements HomeAction {}
 
 class SeeAllClick implements HomeAction {}
-
-class ViewAllClick implements HomeAction {}
 
 class MyJounalClick implements HomeAction {
   final String id;

--- a/lib/presentation/screen/home/home_action.dart
+++ b/lib/presentation/screen/home/home_action.dart
@@ -4,7 +4,7 @@ sealed class HomeAction {
   factory HomeAction.shareClick() = ShareClick;
   factory HomeAction.recentActivityClick() = RecentActivityClick;
   factory HomeAction.seeAllClick() = SeeAllClick;
-  factory HomeAction.myJounalClick(String id) = MyJounalClick;
+  factory HomeAction.myJounalClick(String id) = MyJournalClick;
   factory HomeAction.findUser() = FindUser;
   factory HomeAction.findJounals() = FindJounals;
 }
@@ -19,10 +19,10 @@ class RecentActivityClick implements HomeAction {}
 
 class SeeAllClick implements HomeAction {}
 
-class MyJounalClick implements HomeAction {
+class MyJournalClick implements HomeAction {
   final String id;
 
-  const MyJounalClick(this.id);
+  const MyJournalClick(this.id);
 }
 
 class FindUser implements HomeAction {}

--- a/lib/presentation/screen/home/home_screen.dart
+++ b/lib/presentation/screen/home/home_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:photopin/core/styles/app_color.dart';
 import 'package:photopin/core/styles/app_font.dart';
-import 'package:photopin/journal/domain/model/journal_model.dart';
 import 'package:photopin/presentation/component/journal_card.dart';
 import 'package:photopin/presentation/component/main_icon_card.dart';
 import 'package:photopin/presentation/component/recent_activity_tile.dart';
@@ -56,10 +55,9 @@ class HomeScreen extends StatelessWidget {
                         const SizedBox(width: 12),
                         Expanded(
                           child: MainIconCard(
-                            onTap:
-                                () => {
-                                  // 수정
-                                },
+                            onTap: () {
+                              onAction(HomeAction.newJournalClick());
+                            },
                             title: 'New Journal',
                             iconData: Icons.auto_stories,
                             iconColor: AppColors.secondary100,
@@ -69,7 +67,7 @@ class HomeScreen extends StatelessWidget {
                         Expanded(
                           child: MainIconCard(
                             onTap: () {
-                              // 수정
+                              onAction(HomeAction.shareClick());
                             },
                             title: 'Share',
                             iconData: Icons.share,
@@ -85,7 +83,7 @@ class HomeScreen extends StatelessWidget {
                         const Spacer(),
                         GestureDetector(
                           onTap: () {
-                            // 수정
+                            onAction(HomeAction.seeAllClick());
                           },
                           child: Text(
                             'See all',
@@ -101,45 +99,42 @@ class HomeScreen extends StatelessWidget {
                       title: 'Link shared: Paris Trip',
                       dateTime: DateTime.now(),
                       onTap: () {
-                        // 수정
+                        onAction(HomeAction.recentActivityClick());
                       },
                       iconData: CupertinoIcons.link,
                     ),
                     const SizedBox(height: 24),
-                    Row(
-                      children: [
-                        Text('Your Journals', style: AppFonts.largeTextBold),
-                        const Spacer(),
-                        GestureDetector(
-                          onTap: () {
-                            onAction(HomeAction.viewAllClick());
-                          },
-                          child: Text(
-                            'View all',
-                            style: AppFonts.smallTextRegular.copyWith(
-                              color: AppColors.primary100,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
+                    Text('Your Journals', style: AppFonts.largeTextBold),
                     const SizedBox(height: 12),
-                    JournalCard(
-                      onTap: (value) {
-                        // 수정
+                    ListView.separated(
+                      itemCount: state.journals.length,
+                      shrinkWrap: true,
+                      physics: const AlwaysScrollableScrollPhysics(),
+                      separatorBuilder: (BuildContext context, int index) {
+                        return const SizedBox(height: 18);
                       },
-                      journal: JournalModel(
-                        id: '1',
-                        name: 'name',
-                        tripWith: ['a', 'b'],
-                        startDateMilli:
-                            DateTime(2000, 1, 1).millisecondsSinceEpoch,
-                        endDateMilli:
-                            DateTime(2000, 1, 2).millisecondsSinceEpoch,
-                        comment: 'good',
-                      ),
-                      imageUrl: 'imageUrl',
-                      photoCount: 2,
+                      itemBuilder: (BuildContext context, int index) {
+                        String? thumbnailUrl =
+                            state
+                                        .photoMap[state.journals[index].id]
+                                        ?.isNotEmpty ==
+                                    true
+                                ? state
+                                    .photoMap[state.journals[index].id]!
+                                    .first
+                                    .imageUrl
+                                : null;
+                        int? photoCount =
+                            state.photoMap[state.journals[index].id]?.length;
+                        return JournalCard(
+                          imageUrl: thumbnailUrl,
+                          journal: state.journals[index],
+                          photoCount: photoCount ?? 0,
+                          onTap:
+                              (String journalId) =>
+                                  onAction(HomeAction.myJounalClick(journalId)),
+                        );
+                      },
                     ),
                   ],
                 ),

--- a/lib/presentation/screen/home/home_screen_root.dart
+++ b/lib/presentation/screen/home/home_screen_root.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:photopin/presentation/screen/home/home_action.dart';
 import 'package:photopin/presentation/screen/home/home_screen.dart';
 import 'package:photopin/presentation/screen/home/home_view_model.dart';
@@ -43,9 +42,6 @@ class _HomeScreenRootState extends State<HomeScreenRoot> {
               case SeeAllClick():
                 // TODO: Handle this case.
                 throw UnimplementedError();
-              case ViewAllClick():
-                // TODO: 없앨거
-                context.push('/journals');
               case MyJounalClick():
                 // TODO: Handle this case.
                 throw UnimplementedError();

--- a/lib/presentation/screen/home/home_screen_root.dart
+++ b/lib/presentation/screen/home/home_screen_root.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:photopin/core/routes.dart';
 import 'package:photopin/presentation/screen/home/home_action.dart';
 import 'package:photopin/presentation/screen/home/home_screen.dart';
 import 'package:photopin/presentation/screen/home/home_view_model.dart';
@@ -42,9 +44,8 @@ class _HomeScreenRootState extends State<HomeScreenRoot> {
               case SeeAllClick():
                 // TODO: Handle this case.
                 throw UnimplementedError();
-              case MyJounalClick():
-                // TODO: Handle this case.
-                throw UnimplementedError();
+              case MyJournalClick(id: final journalId):
+                context.push('${Routes.map}/$journalId');
               case FindUser():
                 widget.viewModel.onAction(action);
               case FindJounals():

--- a/lib/presentation/screen/home/home_state.dart
+++ b/lib/presentation/screen/home/home_state.dart
@@ -1,12 +1,14 @@
 import 'package:photopin/journal/domain/model/journal_model.dart';
+import 'package:photopin/photo/domain/model/photo_model.dart';
 import 'package:photopin/user/domain/model/user_model.dart';
 
 class HomeState {
   final bool isLoading;
   final UserModel currentUser;
   final List<JournalModel> journals;
+  final Map<String, List<PhotoModel>> photoMap;
 
-  const HomeState({
+  HomeState({
     this.isLoading = false,
     this.currentUser = const UserModel(
       displayName: '',
@@ -15,17 +17,20 @@ class HomeState {
       profileImg: '',
     ),
     this.journals = const [],
-  });
+    Map<String, List<PhotoModel>> photoMap = const {},
+  }) : photoMap = Map.unmodifiable(photoMap);
 
   HomeState copyWith({
     UserModel? currentUser,
     bool? isLoading,
     List<JournalModel>? journals,
+    Map<String, List<PhotoModel>>? photoMap,
   }) {
     return HomeState(
-      currentUser: currentUser ?? this.currentUser,
       isLoading: isLoading ?? this.isLoading,
+      currentUser: currentUser ?? this.currentUser,
       journals: journals ?? this.journals,
+      photoMap: photoMap != null ? Map.unmodifiable(photoMap) : this.photoMap,
     );
   }
 }

--- a/lib/presentation/screen/home/home_view_model.dart
+++ b/lib/presentation/screen/home/home_view_model.dart
@@ -1,14 +1,20 @@
 import 'package:flutter/widgets.dart';
+import 'package:photopin/core/domain/journal_photo_collection.dart';
 import 'package:photopin/core/usecase/get_current_user_use_case.dart';
+import 'package:photopin/core/usecase/get_journal_list_use_case.dart';
 import 'package:photopin/presentation/screen/home/home_action.dart';
 import 'package:photopin/presentation/screen/home/home_state.dart';
 import 'package:photopin/user/domain/model/user_model.dart';
 
 class HomeViewModel with ChangeNotifier {
   final GetCurrentUserUseCase getCurrentUserUseCase;
-  HomeState _state = const HomeState();
+  final GetJournalListUseCase getJournalListUseCase;
+  HomeState _state = HomeState();
 
-  HomeViewModel({required this.getCurrentUserUseCase});
+  HomeViewModel({
+    required this.getCurrentUserUseCase,
+    required this.getJournalListUseCase,
+  });
 
   HomeState get state => _state;
 
@@ -22,13 +28,31 @@ class HomeViewModel with ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> _findJournals() async {
+    _state = _state.copyWith(isLoading: true);
+    notifyListeners();
+
+    final JournalPhotoCollection collection =
+        await getJournalListUseCase.execute();
+
+    _state = _state.copyWith(isLoading: false, journals: collection.journals);
+    notifyListeners();
+  }
+
   Future<void> init() async {
     _state = _state.copyWith(isLoading: true);
     notifyListeners();
 
     final UserModel user = await getCurrentUserUseCase.execute();
+    final JournalPhotoCollection collection =
+        await getJournalListUseCase.execute();
 
-    _state = _state.copyWith(currentUser: user, isLoading: false);
+    _state = _state.copyWith(
+      currentUser: user,
+      journals: collection.journals,
+      photoMap: collection.photoMap,
+      isLoading: false,
+    );
     notifyListeners();
   }
 
@@ -44,12 +68,10 @@ class HomeViewModel with ChangeNotifier {
         throw UnimplementedError();
       case SeeAllClick():
         throw UnimplementedError();
-      case ViewAllClick():
-        throw UnimplementedError();
       case MyJounalClick():
         throw UnimplementedError();
       case FindJounals():
-        throw UnimplementedError();
+        _findJournals();
       case FindUser():
         _findUser();
     }

--- a/lib/presentation/screen/home/home_view_model.dart
+++ b/lib/presentation/screen/home/home_view_model.dart
@@ -39,6 +39,17 @@ class HomeViewModel with ChangeNotifier {
     notifyListeners();
   }
 
+  // Future<void> _myJournalClick() async {
+  //   _state = _state.copyWith(isLoading: true);
+  //   notifyListeners();
+
+  //   final JournalPhotoCollection collection =
+  //       await getJournalListUseCase.execute();
+
+  //   _state = _state.copyWith(isLoading: false, journals: collection.journals);
+  //   notifyListeners();
+  // }
+
   Future<void> init() async {
     _state = _state.copyWith(isLoading: true);
     notifyListeners();
@@ -68,8 +79,8 @@ class HomeViewModel with ChangeNotifier {
         throw UnimplementedError();
       case SeeAllClick():
         throw UnimplementedError();
-      case MyJounalClick():
-        throw UnimplementedError();
+      case MyJournalClick():
+        break;
       case FindJounals():
         _findJournals();
       case FindUser():

--- a/test/presentation/screen/home/home_view_model_test.dart
+++ b/test/presentation/screen/home/home_view_model_test.dart
@@ -1,61 +1,203 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:photopin/auth/data/repository/auth_repository.dart';
+import 'package:photopin/core/domain/journal_photo_collection.dart';
 import 'package:photopin/core/usecase/get_current_user_use_case.dart';
-import 'package:photopin/presentation/screen/home/home_view_model.dart';
-import 'package:photopin/presentation/screen/home/home_state.dart';
+import 'package:photopin/core/usecase/get_journal_list_use_case.dart';
 import 'package:photopin/presentation/screen/home/home_action.dart';
+import 'package:photopin/presentation/screen/home/home_view_model.dart';
+import 'package:photopin/user/domain/model/user_model.dart';
 
 import '../../../user/fixtures/user_model_fixtures.dart';
 
-class MockAuthRepository extends Mock implements AuthRepository {}
-
+// Mocktail을 사용한 mock 클래스 정의
 class MockGetCurrentUserUseCase extends Mock implements GetCurrentUserUseCase {}
+
+class MockGetJournalListUseCase extends Mock implements GetJournalListUseCase {}
 
 void main() {
   late HomeViewModel viewModel;
-  late GetCurrentUserUseCase mockGetCurrentUserUseCase;
+  late MockGetCurrentUserUseCase mockGetCurrentUserUseCase;
+  late MockGetJournalListUseCase mockGetJournalListUseCase;
+  late JournalPhotoCollection testCollection;
+
+  setUpAll(() {
+    // 이 시점에는 모든 타입이 등록됩니다
+    registerFallbackValue(FindUser());
+  });
 
   setUp(() {
     mockGetCurrentUserUseCase = MockGetCurrentUserUseCase();
-    viewModel = HomeViewModel(getCurrentUserUseCase: mockGetCurrentUserUseCase);
+    mockGetJournalListUseCase = MockGetJournalListUseCase();
+    viewModel = HomeViewModel(
+      getCurrentUserUseCase: mockGetCurrentUserUseCase,
+      getJournalListUseCase: mockGetJournalListUseCase,
+    );
 
-    when(() => mockGetCurrentUserUseCase.execute()).thenAnswer((_) async {
-      return userModelFixtures[0];
+    // 가정: JournalPhotoCollection 구조에 맞게 테스트 데이터 생성
+    testCollection = const JournalPhotoCollection(journals: [], photoMap: {});
+  });
+
+  group('HomeViewModel 테스트', () {
+    test('init 호출 시 사용자와 저널 정보를 함께 로드한다', () async {
+      // given
+      final testUser = userModelFixtures[0]; // A 사용자 사용
+
+      when(
+        () => mockGetCurrentUserUseCase.execute(),
+      ).thenAnswer((_) async => testUser);
+      when(
+        () => mockGetJournalListUseCase.execute(),
+      ).thenAnswer((_) async => testCollection);
+
+      // when
+      await viewModel.init();
+
+      // then
+      expect(viewModel.state.isLoading, false);
+      expect(viewModel.state.currentUser, testUser);
+      expect(viewModel.state.journals, testCollection.journals);
+      expect(viewModel.state.photoMap, testCollection.photoMap);
+      verify(() => mockGetCurrentUserUseCase.execute()).called(1);
+      verify(() => mockGetJournalListUseCase.execute()).called(1);
     });
-  });
 
-  tearDown(() {
-    viewModel.dispose();
-  });
+    test('FindUser 액션 실행 시 사용자 정보만 갱신한다', () async {
+      // given
+      final testUser = userModelFixtures[1]; // B 사용자 사용
+      when(
+        () => mockGetCurrentUserUseCase.execute(),
+      ).thenAnswer((_) async => testUser);
 
-  test('초기 상태는 isLoading=false이고 userName이 비어있어야 한다.', () {
-    expect(viewModel.state.isLoading, false);
-    expect(viewModel.state.currentUser.displayName, '');
-    expect(viewModel.state, const HomeState());
-  });
-
-  group('onAction(FindUser)', () {
-    test('유저 정보 로드 후 userName이 업데이트되고 notifyListeners가 2번 호출되어야 한다.', () async {
-      int notifyCount = 0;
-      List<HomeState> states = [];
-
-      viewModel.addListener(() {
-        notifyCount++;
-        states.add(viewModel.state);
-      });
-
+      // when
       await viewModel.onAction(FindUser());
 
-      expect(notifyCount, 2);
-      expect(states.first.isLoading, true);
-      expect(states.last.isLoading, false);
+      // then
+      expect(viewModel.state.isLoading, false);
+      expect(viewModel.state.currentUser, testUser);
+      expect(viewModel.state.currentUser.displayName, 'B');
+      expect(viewModel.state.currentUser.email, 'example2@example.com');
+      verify(() => mockGetCurrentUserUseCase.execute()).called(1);
+      verifyNever(() => mockGetJournalListUseCase.execute());
+    });
+
+    test('FindJounals 액션 실행 시 저널 정보만 갱신한다', () async {
+      // given
+      when(
+        () => mockGetJournalListUseCase.execute(),
+      ).thenAnswer((_) async => testCollection);
+
+      // when
+      await viewModel.onAction(FindJounals());
+
+      // then
+      expect(viewModel.state.isLoading, false);
+      expect(viewModel.state.journals, testCollection.journals);
+      verify(() => mockGetJournalListUseCase.execute()).called(1);
+      verifyNever(() => mockGetCurrentUserUseCase.execute());
+    });
+
+    test('로딩 상태가 액션 수행 중에 변경된다', () async {
+      // given
+      final testUser = userModelFixtures[0];
+      final completer = Completer<UserModel>();
+
+      // 상태 변경을 추적하기 위한 리스너
+      List<bool> loadingStates = [];
+      viewModel.addListener(() {
+        loadingStates.add(viewModel.state.isLoading);
+      });
+
+      when(
+        () => mockGetCurrentUserUseCase.execute(),
+      ).thenAnswer((_) => completer.future);
+
+      // when
+      final future = viewModel.onAction(FindUser());
+
+      // 첫번째 상태 확인
       expect(
-        states.last.currentUser.displayName,
-        userModelFixtures[0].displayName,
+        viewModel.state.isLoading,
+        true,
+        reason: '액션 실행 직후에는 로딩 상태가 true여야 합니다',
       );
 
-      verify(() => mockGetCurrentUserUseCase.execute()).called(1);
+      // completer 완료
+      completer.complete(testUser);
+
+      // 비동기 작업 완료 대기
+      await future;
+
+      // 액션 완료 후 상태 확인
+      expect(
+        viewModel.state.isLoading,
+        false,
+        reason: '액션 완료 후에는 로딩 상태가 false여야 합니다',
+      );
+
+      // 로딩 상태 변화 확인
+      expect(loadingStates, contains(true), reason: '로딩 상태가 true로 변경되어야 합니다');
+      expect(loadingStates.last, false, reason: '마지막 로딩 상태는 false여야 합니다');
+    });
+
+    test('미구현 액션 호출 시 UnimplementedError를 발생시킨다', () async {
+      // when, then
+      expect(
+        () => viewModel.onAction(RecentActivityClick()),
+        throwsA(isA<UnimplementedError>()),
+      );
+      expect(
+        () => viewModel.onAction(SeeAllClick()),
+        throwsA(isA<UnimplementedError>()),
+      );
+    });
+
+    test('구현된 액션 호출 시 오류가 발생하지 않는다', () async {
+      // when, then
+      // 아직 구현되지 않았지만 에러를 던지지 않는 액션들
+      expect(() => viewModel.onAction(CameraClick()), returnsNormally);
+      expect(() => viewModel.onAction(NewJournalClick()), returnsNormally);
+      expect(() => viewModel.onAction(ShareClick()), returnsNormally);
+      expect(
+        () => viewModel.onAction(const MyJournalClick('journal-id')),
+        returnsNormally,
+      );
+    });
+
+    test('notifyListeners가 상태 변경시 호출된다', () async {
+      // 이 테스트를 위해 ChangeNotifier 기능 테스트
+      // given
+      bool notified = false;
+      viewModel.addListener(() {
+        notified = true;
+      });
+
+      when(
+        () => mockGetCurrentUserUseCase.execute(),
+      ).thenAnswer((_) async => userModelFixtures[0]);
+
+      // when
+      await viewModel.onAction(FindUser());
+
+      // then
+      expect(notified, true);
+    });
+
+    test('MyJournalClick 액션 실행 시 id 파라미터를 정확히 전달한다', () async {
+      // given
+      const journalId = 'test-journal-id';
+
+      // when
+      await viewModel.onAction(const MyJournalClick(journalId));
+
+      // then
+      // 현재 구현에서는 MyJournalClick이 아무 처리를 하지 않지만
+      // 정상적으로 호출되는지 확인합니다
+      expect(
+        () => viewModel.onAction(const MyJournalClick(journalId)),
+        returnsNormally,
+      );
     });
   });
 }


### PR DESCRIPTION
## 🔍 개요 (Summary)

- home에서 journal card 불러오기 성공
- home screen journal card 누르면 이동
- home view model test 수정

---

## ✅ 변경 사항 (Changes)

- 모든 하드 코딩 제거 후 usecase을 이용하여 데이터 불러오기

---

## 📸 스크린샷 (Screenshots, 선택사항)

![image](https://github.com/user-attachments/assets/05c4716a-848e-4ec2-b6a6-079f9246cc73)

---

## 🔗 관련 이슈 (Related Issues)

- Closes #157 

---

## 🧪 테스트 (Test)

- HomeViewModel 테스트 init 호출 시 사용자와 저널 정보를 함께 로드한다
- HomeViewModel 테스트 FindUser 액션 실행 시 사용자 정보만 갱신한다
- HomeViewModel 테스트 FindJounals 액션 실행 시 저널 정보만 갱신한다
- HomeViewModel 테스트 로딩 상태가 액션 수행 중에 변경된다
- HomeViewModel 테스트 미구현 액션 호출 시 UnimplementedError를 발생시킨다
- HomeViewModel 테스트 구현된 액션 호출 시 오류가 발생하지 않는다
- HomeViewModel 테스트 notifyListeners가 상태 변경시 호출된다
- HomeViewModel 테스트 MyJournalClick 액션 실행 시 id 파라미터를 정확히 전달한다
---

## 👀 리뷰어 체크리스트 (For Reviewer)

- [ ] 기능이 명세에 맞게 동작하는지 확인
- [ ] 불필요한 코드/주석이 없는지 확인
- [ ] 테스트가 적절히 작성되었는지 확인
