### PR TITLE
#181 AndroidManifest.xml intent filter 분리

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -32,13 +32,15 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+
+            <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="http"/>
-                <data android:scheme="https" />
-                <data android:scheme="photopin" />
-                <data android:host="photopin.cartel.com" />
+                <data android:scheme="http" android:host="photopin.cartel.com" />
+                <data android:scheme="https" android:host="photopin.cartel.com" />
+                <data android:scheme="photopin" android:host="photopin.cartel.com" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.


### PR DESCRIPTION
## 🔍 개요 (Summary)

- `AndroidManifest.xml`의 `Intent filter`를 분리해서 앱 설치 시 아이콘이 정상적으로 표시되도록 수정

## 🔗 관련 이슈 (Related Issues)

Closes #181 

## 👀 리뷰어 체크리스트 (For Reviewer)

- [ ] 기능이 명세에 맞게 동작하는지 확인
- [ ] 불필요한 코드/주석이 없는지 확인
- [ ] 테스트가 적절히 작성되었는지 확인
