### PR TITLE
#224 feat 메인 이벤트 처리

### DIFF
--- a/lib/camera/usecase/save_picture_in_firebase_use_case.dart
+++ b/lib/camera/usecase/save_picture_in_firebase_use_case.dart
@@ -27,28 +27,32 @@ class SavePictureInFirebaseUseCase {
        _savePhotoUseCase = savePhotoUseCase;
 
   Future<void> execute(ImageData imageData, ImageMime imageMime) async {
-    final Location? location = await _getCurrentLocationUseCase.execute();
+    try {
+      final Location? location = await _getCurrentLocationUseCase.execute();
 
-    if (location != null) {
-      final String downloadUrl = await _uploadFileInStorageUseCase.execute(
-        uuid.generate(),
-        imageData.bytes,
-        imageMime,
-      );
+      if (location != null) {
+        final String downloadUrl = await _uploadFileInStorageUseCase.execute(
+          uuid.generate(),
+          imageData.bytes,
+          imageMime,
+        );
 
-      final String placeName = await _getPlaceNameUseCase.execute(
-        location: location,
-      );
+        final String placeName = await _getPlaceNameUseCase.execute(
+          location: location,
+        );
 
-      PhotoDto dto = PhotoDto(
-        name: placeName,
-        imageUrl: downloadUrl,
-        latitude: location.latitude,
-        longitude: location.longitude,
-        dateTimeMilli: DateTime.now().millisecondsSinceEpoch,
-      );
+        PhotoDto dto = PhotoDto(
+          name: placeName,
+          imageUrl: downloadUrl,
+          latitude: location.latitude,
+          longitude: location.longitude,
+          dateTimeMilli: DateTime.now().millisecondsSinceEpoch,
+        );
 
-      _savePhotoUseCase.execute(dto);
+        _savePhotoUseCase.execute(dto);
+      }
+    } catch (e) {
+      rethrow;
     }
   }
 }

--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
@@ -18,10 +20,11 @@ import 'package:photopin/camera/usecase/launch_camera_use_case.dart';
 import 'package:photopin/camera/usecase/save_picture_in_device_use_case.dart';
 import 'package:photopin/camera/usecase/save_picture_in_firebase_use_case.dart';
 import 'package:photopin/core/firebase/firestore_setup.dart';
-import 'package:photopin/core/usecase/auth_and_user_save_use_case.dart';
 import 'package:photopin/core/service/geolocator_location_service.dart';
 import 'package:photopin/core/service/location_service.dart';
 import 'package:photopin/core/service/push_service.dart';
+import 'package:photopin/core/stream_event/stream_event.dart';
+import 'package:photopin/core/usecase/auth_and_user_save_use_case.dart';
 import 'package:photopin/core/usecase/get_compare_model_use_case.dart';
 import 'package:photopin/core/usecase/get_current_location_use_case.dart';
 import 'package:photopin/core/usecase/get_current_user_use_case.dart';
@@ -33,8 +36,8 @@ import 'package:photopin/core/usecase/get_place_name_use_case.dart';
 import 'package:photopin/core/usecase/link_access_notification_use_case.dart';
 import 'package:photopin/core/usecase/permission_check_use_case.dart';
 import 'package:photopin/core/usecase/save_photo_use_case.dart';
-import 'package:photopin/core/usecase/search_journal_by_date_time_range_use_case.dart';
 import 'package:photopin/core/usecase/save_token_use_case.dart';
+import 'package:photopin/core/usecase/search_journal_by_date_time_range_use_case.dart';
 import 'package:photopin/core/usecase/update_journal_use_case.dart';
 import 'package:photopin/core/usecase/upload_file_in_storage_use_case.dart';
 import 'package:photopin/core/usecase/watch_journals_use_case.dart';
@@ -69,6 +72,7 @@ import 'package:photopin/user/data/repository/user_repository_impl.dart';
 final getIt = GetIt.instance;
 
 void di() {
+  getIt.registerSingleton(StreamController<StreamEvent>());
   getIt.registerLazySingleton(() => FirebaseAuth.instance);
   getIt.registerLazySingleton(() => FirebaseMessaging.instance);
   getIt.registerSingleton<FirebaseStorage>(FirebaseStorage.instance);

--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -85,10 +85,10 @@ void di() {
   getIt.registerSingleton<UserRepository>(UserRepositoryImpl(getIt()));
 
   getIt.registerFactory<MainScreenViewModel>(
-    () => MainScreenViewModel(getCurrentUserUseCase: getIt()),
+        () => MainScreenViewModel(getCurrentUserUseCase: getIt()),
   );
   getIt.registerLazySingleton<TokenRepository>(
-    () => TokenRepositoryImpl(getIt<FirebaseFirestore>()),
+        () => TokenRepositoryImpl(getIt<FirebaseFirestore>()),
   );
 
   getIt.registerSingleton<FirebaseMessagingDataSource>(
@@ -97,71 +97,79 @@ void di() {
 
   // userId 마다 firestore에서 받아오는 photo collection 이 달라져야함으로 싱글톤이 의미가 없음.
   getIt.registerFactoryParam<PhotoDataSource, String, void>(
-    (userId, _) => PhotoDataSourceImpl(
-      photoStore: getIt<FirestoreSetup>().photoFirestore(userId),
-    ),
+        (userId, _) =>
+        PhotoDataSourceImpl(
+          photoStore: getIt<FirestoreSetup>().photoFirestore(userId),
+        ),
   );
 
   getIt.registerFactoryParam<SavePhotoUseCase, String, void>(
-    (userId, _) => SavePhotoUseCase(getIt<PhotoRepository>(param1: userId)),
+        (userId, _) => SavePhotoUseCase(getIt<PhotoRepository>(param1: userId)),
   );
 
   getIt.registerFactoryParam<PhotoRepository, String, void>(
-    (userId, _) => PhotoRepositoryImpl(
-      photoDataSource: getIt<PhotoDataSource>(param1: userId),
-    ),
+        (userId, _) =>
+        PhotoRepositoryImpl(
+          photoDataSource: getIt<PhotoDataSource>(param1: userId),
+        ),
   );
 
   getIt.registerFactoryParam<StorageDataSource, String, void>(
-    (userId, _) => FirebaseStorageDataSource(
-      storage: getIt<FirebaseStorage>(),
-      path: userId,
-    ),
+        (userId, _) =>
+        FirebaseStorageDataSource(
+          storage: getIt<FirebaseStorage>(),
+          path: userId,
+        ),
   );
 
   getIt.registerFactoryParam<GetPhotoListUseCase, String, void>(
-    (userId, _) => GetPhotoListUseCase(
-      photoRepository: getIt<PhotoRepository>(param1: userId),
-    ),
+        (userId, _) =>
+        GetPhotoListUseCase(
+          photoRepository: getIt<PhotoRepository>(param1: userId),
+        ),
   );
 
   getIt.registerLazySingleton<AuthDataSource>(
-    () => AuthDataSourceImpl(auth: getIt()),
+        () => AuthDataSourceImpl(auth: getIt()),
   );
   getIt.registerLazySingleton<AuthRepository>(
-    () => AuthRepositoryImpl(dataSource: getIt()),
+        () => AuthRepositoryImpl(dataSource: getIt()),
   );
 
   getIt.registerFactoryParam<HomeViewModel, String, void>(
-    (userId, _) => HomeViewModel(
-      getCurrentUserUseCase: getIt<GetCurrentUserUseCase>(),
-      journalRepository: getIt<JournalRepository>(param1: userId),
-      getJournalListUseCase: getIt<GetJournalListUseCase>(param1: userId),
-      watchJournalsUserCase: getIt<WatchJournalsUseCase>(param1: userId),
-      permissionCheckUseCase: getIt<PermissionCheckUseCase>(),
-      saveTokenUseCase: getIt<SaveTokenUseCase>(),
-      firebaseMessagingDataSource: getIt<FirebaseMessagingDataSource>(),
-      streamController: getIt<StreamController<StreamEvent>>(),
-    ),
+        (userId, _) =>
+        HomeViewModel(
+          getCurrentUserUseCase: getIt<GetCurrentUserUseCase>(),
+          journalRepository: getIt<JournalRepository>(param1: userId),
+          getJournalListUseCase: getIt<GetJournalListUseCase>(param1: userId),
+          watchJournalsUserCase: getIt<WatchJournalsUseCase>(param1: userId),
+          permissionCheckUseCase: getIt<PermissionCheckUseCase>(),
+          saveTokenUseCase: getIt<SaveTokenUseCase>(),
+          firebaseMessagingDataSource: getIt<FirebaseMessagingDataSource>(),
+          streamController: getIt<StreamController<StreamEvent>>(),
+        ),
   );
 
   getIt.registerFactoryParam<GetJournalListUseCase, String, void>(
-    (userId, _) => GetJournalListUseCase(
-      journalRepository: getIt<JournalRepository>(param1: userId),
-      photoRepository: getIt<PhotoRepository>(param1: userId),
-    ),
+        (userId, _) =>
+        GetJournalListUseCase(
+          journalRepository: getIt<JournalRepository>(param1: userId),
+          photoRepository: getIt<PhotoRepository>(param1: userId),
+        ),
   );
 
   getIt.registerFactoryParam<SearchJournalByDateTimeRangeUseCase, String, void>(
-    (userId, _) => SearchJournalByDateTimeRangeUseCase(
-      journalRepository: getIt<JournalRepository>(param1: userId),
-    ),
+        (userId, _) =>
+        SearchJournalByDateTimeRangeUseCase(
+          journalRepository: getIt<JournalRepository>(param1: userId),
+        ),
   );
 
   getIt.registerFactoryParam<GetPhotoListWithJournalIdUseCase, String, void>(
-    (userId, _) => GetPhotoListWithJournalIdUseCase(
-      photoRepository: getIt<PhotoRepository>(param1: userId),
-    ),
+        (userId, _) =>
+        GetPhotoListWithJournalIdUseCase(
+          photoRepository: getIt<PhotoRepository>(param1: userId),
+        ),
   );
 
   getIt.registerSingleton<GetCurrentUserUseCase>(
@@ -183,25 +191,29 @@ void di() {
   );
 
   getIt.registerFactoryParam<WatchJournalsUseCase, String, void>(
-    (userId, _) => WatchJournalsUseCase(
-      photoRepository: getIt<PhotoRepository>(param1: userId),
-      journalRepository: getIt<JournalRepository>(param1: userId),
-    ),
+        (userId, _) =>
+        WatchJournalsUseCase(
+          photoRepository: getIt<PhotoRepository>(param1: userId),
+          journalRepository: getIt<JournalRepository>(param1: userId),
+        ),
   );
 
   getIt.registerFactoryParam<UpdateJournalUseCase, String, void>(
-    (userId, _) => UpdateJournalUseCase(
-      journalRepository: getIt<JournalRepository>(param1: userId),
-    ),
+        (userId, _) =>
+        UpdateJournalUseCase(
+          journalRepository: getIt<JournalRepository>(param1: userId),
+        ),
   );
 
   getIt.registerFactoryParam<JournalViewModel, String, void>(
-    (userId, _) => JournalViewModel(
-      searchJournalByDateTimeRangeUseCase:
+        (userId, _) =>
+        JournalViewModel(
+          searchJournalByDateTimeRangeUseCase:
           getIt<SearchJournalByDateTimeRangeUseCase>(param1: userId),
-      updateJournalUseCase: getIt<UpdateJournalUseCase>(param1: userId),
-      watchJournalsUserCase: getIt<WatchJournalsUseCase>(param1: userId),
-    ),
+          updateJournalUseCase: getIt<UpdateJournalUseCase>(param1: userId),
+          watchJournalsUserCase: getIt<WatchJournalsUseCase>(param1: userId),
+          streamController: getIt<StreamController<StreamEvent>>(),
+        ),
   );
 
   getIt.registerSingleton<CameraHelper>(ImagePickerCameraHelper());
@@ -211,19 +223,20 @@ void di() {
   );
 
   getIt.registerFactoryParam<UploadFileInStorageUseCase, String, void>(
-    (userId, _) =>
+        (userId, _) =>
         UploadFileInStorageUseCase(getIt<StorageDataSource>(param1: userId)),
   );
 
   getIt.registerFactoryParam<SavePictureInFirebaseUseCase, String, void>(
-    (userId, _) => SavePictureInFirebaseUseCase(
-      getCurrentLocationUseCase: getIt<GetCurrentLocationUseCase>(),
-      savePhotoUseCase: getIt<SavePhotoUseCase>(param1: userId),
-      uploadFileInStorageUseCase: getIt<UploadFileInStorageUseCase>(
-        param1: userId,
-      ),
-      getPlaceNameUseCase: getIt<GetPlaceNameUseCase>(),
-    ),
+        (userId, _) =>
+        SavePictureInFirebaseUseCase(
+          getCurrentLocationUseCase: getIt<GetCurrentLocationUseCase>(),
+          savePhotoUseCase: getIt<SavePhotoUseCase>(param1: userId),
+          uploadFileInStorageUseCase: getIt<UploadFileInStorageUseCase>(
+            param1: userId,
+          ),
+          getPlaceNameUseCase: getIt<GetPlaceNameUseCase>(),
+        ),
   );
 
   getIt.registerSingleton<LocalDeviceRepository>(
@@ -237,15 +250,16 @@ void di() {
   );
 
   getIt.registerFactoryParam<CameraViewModel, String, void>(
-    (userId, _) => CameraViewModel(
-      savePictureInDeviceUseCase: getIt<SavePictureInDeviceUseCase>(),
-      launchCameraUseCase: getIt<LaunchCameraUseCase>(),
-      launchCameraCheckPermissionUseCase:
+        (userId, _) =>
+        CameraViewModel(
+          savePictureInDeviceUseCase: getIt<SavePictureInDeviceUseCase>(),
+          launchCameraUseCase: getIt<LaunchCameraUseCase>(),
+          launchCameraCheckPermissionUseCase:
           getIt<LaunchCameraCheckPermissionUseCase>(),
-      savePictureInFirebaseUseCase: getIt<SavePictureInFirebaseUseCase>(
-        param1: userId,
-      ),
-    ),
+          savePictureInFirebaseUseCase: getIt<SavePictureInFirebaseUseCase>(
+            param1: userId,
+          ),
+        ),
   );
 
   getIt.registerSingleton<GetPlaceNameUseCase>(
@@ -260,50 +274,57 @@ void di() {
   );
 
   getIt.registerFactory<AuthViewModel>(
-    () => AuthViewModel(
-      authRepository: getIt<AuthRepository>(),
-      authAndUserSaveUseCase: getIt<AuthAndUserSaveUseCase>(),
-    ),
+        () =>
+        AuthViewModel(
+          authRepository: getIt<AuthRepository>(),
+          authAndUserSaveUseCase: getIt<AuthAndUserSaveUseCase>(),
+        ),
   );
 
   getIt.registerFactoryParam<JournalDataSource, String, void>(
-    (userId, _) => JournalDataSourceImpl(
-      journalStore: getIt<FirestoreSetup>().journalFirestore(userId),
-    ),
+        (userId, _) =>
+        JournalDataSourceImpl(
+          journalStore: getIt<FirestoreSetup>().journalFirestore(userId),
+        ),
   );
 
   getIt.registerFactoryParam<JournalRepository, String, void>(
-    (userId, _) => JournalRepositoryImpl(
-      dataSource: getIt<JournalDataSource>(param1: userId),
-    ),
+        (userId, _) =>
+        JournalRepositoryImpl(
+          dataSource: getIt<JournalDataSource>(param1: userId),
+        ),
   );
 
   getIt.registerFactoryParam<MapViewModel, String, void>(
-    (userId, _) => MapViewModel(
-      photoRepository: getIt<PhotoRepository>(param1: userId),
-      getCompareModelUseCase: getIt<GetCompareModelUseCase>(param1: userId),
-    ),
+        (userId, _) =>
+        MapViewModel(
+          photoRepository: getIt<PhotoRepository>(param1: userId),
+          getCompareModelUseCase: getIt<GetCompareModelUseCase>(param1: userId),
+        ),
   );
 
   getIt.registerFactoryParam<PhotosViewModel, String, void>(
-    (userId, _) => PhotosViewModel(
-      getPhotoListUseCase: getIt<GetPhotoListUseCase>(param1: userId),
-      getJournalListUseCase: getIt<GetJournalListUseCase>(param1: userId),
-      getPhotoListWithJournalIdUseCase: getIt<GetPhotoListWithJournalIdUseCase>(
-        param1: userId,
-      ),
-      photoRepository: getIt<PhotoRepository>(param1: userId),
-      getPhotoJournalListUseCase: getIt<GetPhotoJournalListUseCase>(
-        param1: userId,
-      ),
-    ),
+        (userId, _) =>
+        PhotosViewModel(
+          getPhotoListUseCase: getIt<GetPhotoListUseCase>(param1: userId),
+          getJournalListUseCase: getIt<GetJournalListUseCase>(param1: userId),
+          getPhotoListWithJournalIdUseCase: getIt<
+              GetPhotoListWithJournalIdUseCase>(
+            param1: userId,
+          ),
+          photoRepository: getIt<PhotoRepository>(param1: userId),
+          getPhotoJournalListUseCase: getIt<GetPhotoJournalListUseCase>(
+            param1: userId,
+          ),
+        ),
   );
 
   getIt.registerFactoryParam<GetPhotoJournalListUseCase, String, void>(
-    (userId, _) => GetPhotoJournalListUseCase(
-      journalRepository: getIt<JournalRepository>(param1: userId),
-      photoRepository: getIt<PhotoRepository>(param1: userId),
-    ),
+        (userId, _) =>
+        GetPhotoJournalListUseCase(
+          journalRepository: getIt<JournalRepository>(param1: userId),
+          photoRepository: getIt<PhotoRepository>(param1: userId),
+        ),
   );
 
   getIt.registerSingleton<SettingsViewModel>(
@@ -311,18 +332,20 @@ void di() {
   );
 
   getIt.registerFactoryParam<GetCompareModelUseCase, String, void>(
-    (userId, _) => GetCompareModelUseCase(
-      journalRepository: getIt<JournalRepository>(param1: userId),
-      photoRepository: getIt<PhotoRepository>(param1: userId),
-      userRepository: getIt<UserRepository>(),
-    ),
+        (userId, _) =>
+        GetCompareModelUseCase(
+          journalRepository: getIt<JournalRepository>(param1: userId),
+          photoRepository: getIt<PhotoRepository>(param1: userId),
+          userRepository: getIt<UserRepository>(),
+        ),
   );
 
   getIt.registerFactoryParam<CompareMapViewModel, String, String>(
-    (compareUserId, myUserId) => CompareMapViewModel(
-      sharedUseCase: getIt<GetCompareModelUseCase>(param1: compareUserId),
-      myUseCase: getIt<GetCompareModelUseCase>(param1: myUserId),
-    ),
+        (compareUserId, myUserId) =>
+        CompareMapViewModel(
+          sharedUseCase: getIt<GetCompareModelUseCase>(param1: compareUserId),
+          myUseCase: getIt<GetCompareModelUseCase>(param1: myUserId),
+        ),
   );
 
   getIt.registerLazySingleton<PushService>(() => PushService());
@@ -335,10 +358,11 @@ void di() {
   );
 
   getIt.registerFactoryParam<CompareDialogViewModel, String, void>(
-    (userId, _) => CompareDialogViewModel(
-      repository: getIt<JournalRepository>(param1: userId),
-      linkAccessNotificationuseCase: getIt<LinkAccessNotificationUseCase>(),
-    ),
+        (userId, _) =>
+        CompareDialogViewModel(
+          repository: getIt<JournalRepository>(param1: userId),
+          linkAccessNotificationuseCase: getIt<LinkAccessNotificationUseCase>(),
+        ),
   );
 
   getIt.registerSingleton<SaveTokenUseCase>(SaveTokenUseCase(getIt()));

--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -103,7 +103,10 @@ void di() {
   );
 
   getIt.registerFactoryParam<SavePhotoUseCase, String, void>(
-    (userId, _) => SavePhotoUseCase(getIt<PhotoRepository>(param1: userId)),
+    (userId, _) => SavePhotoUseCase(
+      getIt<PhotoRepository>(param1: userId),
+      getIt<StreamController<StreamEvent>>(),
+    ),
   );
 
   getIt.registerFactoryParam<PhotoRepository, String, void>(
@@ -296,6 +299,7 @@ void di() {
       getPhotoJournalListUseCase: getIt<GetPhotoJournalListUseCase>(
         param1: userId,
       ),
+      streamController: getIt<StreamController<StreamEvent>>(),
     ),
   );
 

--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -141,6 +141,7 @@ void di() {
       permissionCheckUseCase: getIt<PermissionCheckUseCase>(),
       saveTokenUseCase: getIt<SaveTokenUseCase>(),
       firebaseMessagingDataSource: getIt<FirebaseMessagingDataSource>(),
+      streamController: getIt<StreamController<StreamEvent>>(),
     ),
   );
 

--- a/lib/core/enums/action_type.dart
+++ b/lib/core/enums/action_type.dart
@@ -1,4 +1,4 @@
-enum StreamEventSuccess {
+enum ActionType {
   journalCreate('저널이 생성되었습니다.'),
   journalDelete('저널이 삭제되었습니다.'),
   journalUpdate('저널이 수정되었습니다.'),
@@ -9,5 +9,5 @@ enum StreamEventSuccess {
 
   final String message;
 
-  const StreamEventSuccess(this.message);
+  const ActionType(this.message);
 }

--- a/lib/core/enums/error_type.dart
+++ b/lib/core/enums/error_type.dart
@@ -1,4 +1,4 @@
-enum StreamEventError implements Exception {
+enum ErrorType implements Exception {
   journalCreate('저널이 생성에 실패하였습니다.'),
   journalDelete('저널 삭제에 실패하였습니다.'),
   journalUpdate('저널 수정이 실패하였습니다.'),
@@ -9,5 +9,5 @@ enum StreamEventError implements Exception {
 
   final String message;
 
-  const StreamEventError(this.message);
+  const ErrorType(this.message);
 }

--- a/lib/core/enums/stream_event_error.dart
+++ b/lib/core/enums/stream_event_error.dart
@@ -1,0 +1,13 @@
+enum StreamEventError implements Exception {
+  journalCreate('저널이 생성에 실패하였습니다.'),
+  journalDelete('저널 삭제에 실패하였습니다.'),
+  journalUpdate('저널 수정이 실패하였습니다.'),
+  photoSave('사진이 저장에 실패하였습니다.'),
+  photoDelete('사진 삭제에 실패하였습니다.'),
+  photoUpdate('사진 정보가 변경에 실패하였습니다.'),
+  photoInJournal('사진이 저널 추가에 실패하였습니다.');
+
+  final String message;
+
+  const StreamEventError(this.message);
+}

--- a/lib/core/enums/stream_event_success.dart
+++ b/lib/core/enums/stream_event_success.dart
@@ -1,0 +1,13 @@
+enum StreamEventSuccess {
+  journalCreate('저널이 생성되었습니다.'),
+  journalDelete('저널이 삭제되었습니다.'),
+  journalUpdate('저널이 수정되었습니다.'),
+  photoSave('사진이 저장되었습니다.'),
+  photoDelete('사진이 삭제되었습니다.'),
+  photoUpdate('사진 정보가 변경되었습니다.'),
+  photoInJournal('사진이 저널에 추가되었습니다.');
+
+  final String message;
+
+  const StreamEventSuccess(this.message);
+}

--- a/lib/core/mixins/event_notifier.dart
+++ b/lib/core/mixins/event_notifier.dart
@@ -6,9 +6,7 @@ import 'package:photopin/core/stream_event/stream_event.dart';
 abstract class EventNotifier with ChangeNotifier {
   StreamController<StreamEvent> streamController;
 
-  EventNotifier({
-    required this.streamController,
-  });
+  EventNotifier({required this.streamController});
 
   void addEvent(StreamEvent event) {
     streamController.add(event);
@@ -19,6 +17,4 @@ abstract class EventNotifier with ChangeNotifier {
     streamController.close();
     super.dispose();
   }
-
-
 }

--- a/lib/core/mixins/event_notifier.dart
+++ b/lib/core/mixins/event_notifier.dart
@@ -1,0 +1,22 @@
+import 'dart:async';
+
+import 'package:flutter/cupertino.dart';
+import 'package:photopin/core/stream_event/stream_event.dart';
+
+mixin EventNotifier on ChangeNotifier {
+  late StreamController<StreamEvent> streamController;
+
+  void initStreamController(StreamController<StreamEvent> event) {
+    streamController = event;
+  }
+
+  void addEvent(StreamEvent event) {
+    streamController.add(event);
+  }
+
+  @override
+  void dispose() {
+    streamController.close();
+    super.dispose();
+  }
+}

--- a/lib/core/mixins/event_notifier.dart
+++ b/lib/core/mixins/event_notifier.dart
@@ -3,12 +3,12 @@ import 'dart:async';
 import 'package:flutter/cupertino.dart';
 import 'package:photopin/core/stream_event/stream_event.dart';
 
-mixin EventNotifier on ChangeNotifier {
-  late StreamController<StreamEvent> streamController;
+abstract class EventNotifier with ChangeNotifier {
+  StreamController<StreamEvent> streamController;
 
-  void initStreamController(StreamController<StreamEvent> event) {
-    streamController = event;
-  }
+  EventNotifier({
+    required this.streamController,
+  });
 
   void addEvent(StreamEvent event) {
     streamController.add(event);
@@ -19,4 +19,6 @@ mixin EventNotifier on ChangeNotifier {
     streamController.close();
     super.dispose();
   }
+
+
 }

--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -160,15 +160,15 @@ final appRouter = GoRouter(
                   path: '${Routes.compare}/:userId/:journalId',
                   builder: (BuildContext context, GoRouterState state) {
                     final String compareUserId =
-                    state.pathParameters['userId']!;
+                        state.pathParameters['userId']!;
                     final String compareJournalId =
-                    state.pathParameters['journalId']!;
+                        state.pathParameters['journalId']!;
 
                     final String myUserId =
                         getIt<FirebaseAuth>().currentUser!.uid;
 
                     final CompareDialogViewModel viewModel =
-                    getIt<CompareDialogViewModel>(param1: myUserId);
+                        getIt<CompareDialogViewModel>(param1: myUserId);
 
                     viewModel.init();
 

--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -5,6 +7,7 @@ import 'package:photopin/camera/presentation/camera_launcher_screen_root.dart';
 import 'package:photopin/camera/presentation/camera_view_model.dart';
 import 'package:photopin/core/di/di_setup.dart';
 import 'package:photopin/core/routes.dart';
+import 'package:photopin/core/stream_event/stream_event.dart';
 import 'package:photopin/presentation/screen/auth/auth_screen_root.dart';
 import 'package:photopin/presentation/screen/auth/auth_view_model.dart';
 import 'package:photopin/presentation/screen/compare_dialog/compare_dialog_screen_root.dart';
@@ -133,6 +136,7 @@ final appRouter = GoRouter(
         return MainScreenRoot(
           navigationShell: navigationShell,
           viewModel: mainScreenViewModel,
+          streamController: getIt<StreamController<StreamEvent>>(),
         );
       },
       branches: [
@@ -156,15 +160,15 @@ final appRouter = GoRouter(
                   path: '${Routes.compare}/:userId/:journalId',
                   builder: (BuildContext context, GoRouterState state) {
                     final String compareUserId =
-                        state.pathParameters['userId']!;
+                    state.pathParameters['userId']!;
                     final String compareJournalId =
-                        state.pathParameters['journalId']!;
+                    state.pathParameters['journalId']!;
 
                     final String myUserId =
                         getIt<FirebaseAuth>().currentUser!.uid;
 
                     final CompareDialogViewModel viewModel =
-                        getIt<CompareDialogViewModel>(param1: myUserId);
+                    getIt<CompareDialogViewModel>(param1: myUserId);
 
                     viewModel.init();
 

--- a/lib/core/stream_event/stream_event.dart
+++ b/lib/core/stream_event/stream_event.dart
@@ -1,20 +1,20 @@
-import 'package:photopin/core/enums/stream_event_error.dart';
-import 'package:photopin/core/enums/stream_event_success.dart';
+import 'package:photopin/core/enums/action_type.dart';
+import 'package:photopin/core/enums/error_type.dart';
 
 sealed class StreamEvent {
-  const factory StreamEvent.success(StreamEventSuccess success) = Success;
+  const factory StreamEvent.success(ActionType success) = Success;
 
-  const factory StreamEvent.error(StreamEventError error) = Error;
+  const factory StreamEvent.error(ErrorType error) = Error;
 }
 
 class Success implements StreamEvent {
-  final StreamEventSuccess success;
+  final ActionType success;
 
   const Success(this.success);
 }
 
 class Error implements StreamEvent {
-  final StreamEventError error;
+  final ErrorType error;
 
   const Error(this.error);
 }

--- a/lib/core/stream_event/stream_event.dart
+++ b/lib/core/stream_event/stream_event.dart
@@ -1,0 +1,20 @@
+import 'package:photopin/core/enums/stream_event_error.dart';
+import 'package:photopin/core/enums/stream_event_success.dart';
+
+sealed class StreamEvent {
+  const factory StreamEvent.success(StreamEventSuccess success) = Success;
+
+  const factory StreamEvent.error(StreamEventError error) = Error;
+}
+
+class Success implements StreamEvent {
+  final StreamEventSuccess success;
+
+  const Success(this.success);
+}
+
+class Error implements StreamEvent {
+  final StreamEventError error;
+
+  const Error(this.error);
+}

--- a/lib/core/usecase/save_photo_use_case.dart
+++ b/lib/core/usecase/save_photo_use_case.dart
@@ -1,13 +1,24 @@
+import 'dart:async';
+
+import 'package:photopin/core/enums/action_type.dart';
+import 'package:photopin/core/enums/error_type.dart';
+import 'package:photopin/core/stream_event/stream_event.dart';
 import 'package:photopin/photo/data/dto/photo_dto.dart';
 import 'package:photopin/photo/data/mapper/photo_mapper.dart';
 import 'package:photopin/photo/data/repository/photo_repository.dart';
 
 class SavePhotoUseCase {
   final PhotoRepository _photoRepository;
+  final StreamController<StreamEvent> streamController;
 
-  const SavePhotoUseCase(this._photoRepository);
+  const SavePhotoUseCase(this._photoRepository, this.streamController);
 
   Future<void> execute(PhotoDto dto) async {
-    await _photoRepository.savePhoto(dto.toModel());
+    try {
+      await _photoRepository.savePhoto(dto.toModel());
+      streamController.add(const StreamEvent.success(ActionType.photoSave));
+    } catch (e) {
+      streamController.add(const StreamEvent.error(ErrorType.photoSave));
+    }
   }
 }

--- a/lib/journal/data/data_source/journal_data_source_impl.dart
+++ b/lib/journal/data/data_source/journal_data_source_impl.dart
@@ -46,17 +46,25 @@ class JournalDataSourceImpl implements JournalDataSource {
 
   @override
   Future<void> deleteJournal(String journalId) async {
-    await _journalStore.doc(journalId).delete();
+    try {
+      await _journalStore.doc(journalId).delete();
+    } catch (e) {
+      rethrow;
+    }
   }
 
   @override
   Future<void> saveJournal(JournalDto dto) async {
-    final DocumentReference<JournalDto> journaldoc = await _journalStore.add(
-      dto,
-    );
-    final String docId = journaldoc.id;
+    try {
+      final DocumentReference<JournalDto> journaldoc = await _journalStore.add(
+        dto,
+      );
+      final String docId = journaldoc.id;
 
-    await _journalStore.doc(docId).update({'id': docId});
+      await _journalStore.doc(docId).update({'id': docId});
+    } catch (e) {
+      rethrow;
+    }
   }
 
   @override
@@ -87,7 +95,11 @@ class JournalDataSourceImpl implements JournalDataSource {
 
   @override
   Future<void> update(JournalDto journal) async {
-    await _journalStore.doc(journal.id).set(journal, SetOptions(merge: true));
+    try {
+      await _journalStore.doc(journal.id).set(journal, SetOptions(merge: true));
+    } catch (e) {
+      rethrow;
+    }
   }
 
   @override

--- a/lib/journal/data/repository/journal_repository_impl.dart
+++ b/lib/journal/data/repository/journal_repository_impl.dart
@@ -24,12 +24,20 @@ class JournalRepositoryImpl implements JournalRepository {
 
   @override
   Future<void> saveJournal(JournalDto dto) async {
-    await _dataSource.saveJournal(dto);
+    try {
+      await _dataSource.saveJournal(dto);
+    } catch (e) {
+      rethrow;
+    }
   }
 
   @override
   Future<void> deleteJournal(String journalId) async {
-    await _dataSource.deleteJournal(journalId);
+    try {
+      await _dataSource.deleteJournal(journalId);
+    } catch (e) {
+      rethrow;
+    }
   }
 
   @override
@@ -41,7 +49,11 @@ class JournalRepositoryImpl implements JournalRepository {
 
   @override
   Future<void> update(JournalModel journal) async {
-    await _dataSource.update(journal.toDto());
+    try {
+      await _dataSource.update(journal.toDto());
+    } catch (e) {
+      rethrow;
+    }
   }
 
   @override

--- a/lib/photo/data/data_source/photo_data_source_impl.dart
+++ b/lib/photo/data/data_source/photo_data_source_impl.dart
@@ -67,20 +67,32 @@ class PhotoDataSourceImpl implements PhotoDataSource {
 
   @override
   Future<void> deletePhoto(String photoId) async {
-    await _photoStore.doc(photoId).delete();
+    try {
+      await _photoStore.doc(photoId).delete();
+    } catch (e) {
+      rethrow;
+    }
   }
 
   @override
   Future<void> savePhoto(PhotoDto dto) async {
-    final DocumentReference<PhotoDto> photodoc = await _photoStore.add(dto);
-    final String docId = photodoc.id;
+    try {
+      final DocumentReference<PhotoDto> photodoc = await _photoStore.add(dto);
+      final String docId = photodoc.id;
 
-    await _photoStore.doc(docId).update({'id': docId});
+      await _photoStore.doc(docId).update({'id': docId});
+    } catch (e) {
+      rethrow;
+    }
   }
 
   @override
   Future<void> updatePhoto(PhotoDto photoDto) async {
-    await _photoStore.doc(photoDto.id).set(photoDto, SetOptions(merge: true));
+    try {
+      await _photoStore.doc(photoDto.id).set(photoDto, SetOptions(merge: true));
+    } catch (e) {
+      rethrow;
+    }
   }
 
   @override

--- a/lib/photo/data/repository/photo_repository_impl.dart
+++ b/lib/photo/data/repository/photo_repository_impl.dart
@@ -11,7 +11,11 @@ class PhotoRepositoryImpl implements PhotoRepository {
 
   @override
   Future<void> deletePhoto(String photoId) async {
-    await _photoDataSource.deletePhoto(photoId);
+    try {
+      await _photoDataSource.deletePhoto(photoId);
+    } catch (e) {
+      rethrow;
+    }
   }
 
   @override
@@ -53,12 +57,20 @@ class PhotoRepositoryImpl implements PhotoRepository {
 
   @override
   Future<void> savePhoto(PhotoModel model) async {
-    await _photoDataSource.savePhoto(model.toDto());
+    try {
+      await _photoDataSource.savePhoto(model.toDto());
+    } catch (e) {
+      rethrow;
+    }
   }
 
   @override
   Future<void> updatePhoto(PhotoModel photoModel) async {
-    await _photoDataSource.updatePhoto(photoModel.toDto());
+    try {
+      await _photoDataSource.updatePhoto(photoModel.toDto());
+    } catch (e) {
+      rethrow;
+    }
   }
 
   @override

--- a/lib/presentation/component/new_journal_modal.dart
+++ b/lib/presentation/component/new_journal_modal.dart
@@ -74,6 +74,7 @@ class _NewJournalModalState extends State<NewJournalModal> {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
+      backgroundColor: AppColors.white,
       content: SizedBox(
         height: 360,
         child: Column(

--- a/lib/presentation/screen/home/home_view_model.dart
+++ b/lib/presentation/screen/home/home_view_model.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
-import 'package:flutter/widgets.dart';
 import 'package:photopin/core/domain/journal_photo_collection.dart';
+import 'package:photopin/core/enums/action_type.dart';
 import 'package:photopin/core/enums/permission_type.dart';
 import 'package:photopin/core/mixins/event_notifier.dart';
 import 'package:photopin/core/stream_event/stream_event.dart';
@@ -18,7 +18,7 @@ import 'package:photopin/presentation/screen/home/home_action.dart';
 import 'package:photopin/presentation/screen/home/home_state.dart';
 import 'package:photopin/user/domain/model/user_model.dart';
 
-class HomeViewModel with ChangeNotifier, EventNotifier {
+class HomeViewModel extends EventNotifier {
   final GetCurrentUserUseCase getCurrentUserUseCase;
   final JournalRepository _journalRepository;
   final GetJournalListUseCase getJournalListUseCase;
@@ -31,6 +31,7 @@ class HomeViewModel with ChangeNotifier, EventNotifier {
   HomeState _state = HomeState();
 
   HomeViewModel({
+    required super.streamController,
     required this.getCurrentUserUseCase,
     required JournalRepository journalRepository,
     required this.getJournalListUseCase,
@@ -38,14 +39,11 @@ class HomeViewModel with ChangeNotifier, EventNotifier {
     required PermissionCheckUseCase permissionCheckUseCase,
     required SaveTokenUseCase saveTokenUseCase,
     required FirebaseMessagingDataSource firebaseMessagingDataSource,
-    required StreamController<StreamEvent> streamController,
   }) : _journalRepository = journalRepository,
        _watchJournalsUserCase = watchJournalsUserCase,
        _permissionCheckUseCase = permissionCheckUseCase,
        _firebaseMessagingDataSource = firebaseMessagingDataSource,
-       _saveTokenUseCase = saveTokenUseCase {
-    initStreamController(streamController);
-  }
+       _saveTokenUseCase = saveTokenUseCase;
 
   HomeState get state => _state;
 
@@ -67,6 +65,7 @@ class HomeViewModel with ChangeNotifier, EventNotifier {
 
   Future<void> _newJournalSave({required JournalModel journal}) async {
     await _journalRepository.saveJournal(journal.toDto());
+    addEvent(const StreamEvent.success(ActionType.journalCreate));
   }
 
   Future<void> _findJournals() async {

--- a/lib/presentation/screen/home/home_view_model.dart
+++ b/lib/presentation/screen/home/home_view_model.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:photopin/core/domain/journal_photo_collection.dart';
 import 'package:photopin/core/enums/permission_type.dart';
+import 'package:photopin/core/mixins/event_notifier.dart';
+import 'package:photopin/core/stream_event/stream_event.dart';
 import 'package:photopin/core/usecase/get_current_user_use_case.dart';
 import 'package:photopin/core/usecase/get_journal_list_use_case.dart';
 import 'package:photopin/core/usecase/permission_check_use_case.dart';
@@ -16,7 +18,7 @@ import 'package:photopin/presentation/screen/home/home_action.dart';
 import 'package:photopin/presentation/screen/home/home_state.dart';
 import 'package:photopin/user/domain/model/user_model.dart';
 
-class HomeViewModel with ChangeNotifier {
+class HomeViewModel with ChangeNotifier, EventNotifier {
   final GetCurrentUserUseCase getCurrentUserUseCase;
   final JournalRepository _journalRepository;
   final GetJournalListUseCase getJournalListUseCase;
@@ -36,11 +38,14 @@ class HomeViewModel with ChangeNotifier {
     required PermissionCheckUseCase permissionCheckUseCase,
     required SaveTokenUseCase saveTokenUseCase,
     required FirebaseMessagingDataSource firebaseMessagingDataSource,
+    required StreamController<StreamEvent> streamController,
   }) : _journalRepository = journalRepository,
        _watchJournalsUserCase = watchJournalsUserCase,
        _permissionCheckUseCase = permissionCheckUseCase,
        _firebaseMessagingDataSource = firebaseMessagingDataSource,
-       _saveTokenUseCase = saveTokenUseCase;
+       _saveTokenUseCase = saveTokenUseCase {
+    initStreamController(streamController);
+  }
 
   HomeState get state => _state;
 

--- a/lib/presentation/screen/journal/journal_view_model.dart
+++ b/lib/presentation/screen/journal/journal_view_model.dart
@@ -2,7 +2,11 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:photopin/core/domain/journal_photo_collection.dart';
+import 'package:photopin/core/enums/action_type.dart';
+import 'package:photopin/core/enums/error_type.dart';
 import 'package:photopin/core/enums/search_filter_option.dart';
+import 'package:photopin/core/mixins/event_notifier.dart';
+import 'package:photopin/core/stream_event/stream_event.dart';
 import 'package:photopin/core/usecase/search_journal_by_date_time_range_use_case.dart';
 import 'package:photopin/core/usecase/update_journal_use_case.dart';
 import 'package:photopin/core/usecase/watch_journals_use_case.dart';
@@ -10,7 +14,7 @@ import 'package:photopin/journal/domain/model/journal_model.dart';
 import 'package:photopin/presentation/screen/journal/journal_screen_action.dart';
 import 'package:photopin/presentation/screen/journal/journal_state.dart';
 
-class JournalViewModel with ChangeNotifier {
+class JournalViewModel extends EventNotifier {
   JournalState _state = JournalState();
   StreamSubscription<JournalPhotoCollection>? _journalSubscription;
 
@@ -20,6 +24,7 @@ class JournalViewModel with ChangeNotifier {
   _searchJournalByDateTimeRangeUseCase;
 
   JournalViewModel({
+    required super.streamController,
     required WatchJournalsUseCase watchJournalsUserCase,
     required UpdateJournalUseCase updateJournalUseCase,
     required SearchJournalByDateTimeRangeUseCase
@@ -30,6 +35,7 @@ class JournalViewModel with ChangeNotifier {
            searchJournalByDateTimeRangeUseCase;
 
   JournalState get state => _state;
+
   bool get isLoading => _state.isLoading;
 
   @override
@@ -122,7 +128,12 @@ class JournalViewModel with ChangeNotifier {
     _state = _state.copyWith(isLoading: true);
     notifyListeners();
 
-    await _updateJournalUseCase.execute(journal);
+    try {
+      await _updateJournalUseCase.execute(journal);
+      addEvent(const StreamEvent.success(ActionType.journalUpdate));
+    } catch (e) {
+      addEvent(const StreamEvent.error(ErrorType.journalUpdate));
+    }
 
     _state = _state.copyWith(isLoading: false);
     notifyListeners();

--- a/lib/presentation/screen/main/main_screen_root.dart
+++ b/lib/presentation/screen/main/main_screen_root.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
+import 'package:alert_info/alert_info.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:photopin/core/stream_event/stream_event.dart';
 import 'package:photopin/core/styles/app_color.dart';
-import 'package:photopin/core/styles/app_font.dart';
 import 'package:photopin/presentation/screen/main/main_screen.dart';
 import 'package:photopin/presentation/screen/main/main_view_model.dart';
 
@@ -30,27 +30,22 @@ class _MainScreenRootState extends State<MainScreenRoot> {
   void initState() {
     super.initState();
     _streamSubscription = widget.streamController.stream.listen((e) {
-      switch (e) {
-        case Success():
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(
-                e.success.message,
-                style: AppFonts.mediumTextBold.copyWith(color: AppColors.black),
-              ),
-              backgroundColor: AppColors.secondary100,
-            ),
-          );
-        case Error():
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(
-                e.error.message,
-                style: AppFonts.mediumTextBold.copyWith(color: AppColors.black),
-              ),
-              backgroundColor: AppColors.warningBackground,
-            ),
-          );
+      if (mounted) {
+        switch (e) {
+          case Success():
+            AlertInfo.show(
+              context: context,
+              text: e.success.message,
+              icon: Icons.check,
+            );
+          case Error():
+            AlertInfo.show(
+              context: context,
+              text: e.error.message,
+              icon: Icons.warning_amber,
+              iconColor: AppColors.warning,
+            );
+        }
       }
     });
   }

--- a/lib/presentation/screen/main/main_screen_root.dart
+++ b/lib/presentation/screen/main/main_screen_root.dart
@@ -1,26 +1,74 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:photopin/core/stream_event/stream_event.dart';
+import 'package:photopin/core/styles/app_color.dart';
+import 'package:photopin/core/styles/app_font.dart';
 import 'package:photopin/presentation/screen/main/main_screen.dart';
 import 'package:photopin/presentation/screen/main/main_view_model.dart';
 
-class MainScreenRoot extends StatelessWidget {
+class MainScreenRoot extends StatefulWidget {
   final MainScreenViewModel viewModel;
   final StatefulNavigationShell navigationShell;
+  final StreamController<StreamEvent> streamController;
 
   const MainScreenRoot({
-    super.key,
     required this.viewModel,
     required this.navigationShell,
+    required this.streamController,
   });
+
+  @override
+  State<MainScreenRoot> createState() => _MainScreenRootState();
+}
+
+class _MainScreenRootState extends State<MainScreenRoot> {
+  StreamSubscription<StreamEvent>? _streamSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _streamSubscription = widget.streamController.stream.listen((e) {
+      switch (e) {
+        case Success():
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                e.success.message,
+                style: AppFonts.mediumTextBold.copyWith(color: AppColors.black),
+              ),
+              backgroundColor: AppColors.secondary100,
+            ),
+          );
+        case Error():
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                e.error.message,
+                style: AppFonts.mediumTextBold.copyWith(color: AppColors.black),
+              ),
+              backgroundColor: AppColors.warningBackground,
+            ),
+          );
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _streamSubscription?.cancel();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return ListenableBuilder(
-      listenable: viewModel,
+      listenable: widget.viewModel,
       builder: (context, child) {
         return MainScreen(
-          navigationShell: navigationShell,
-          state: viewModel.state,
+          navigationShell: widget.navigationShell,
+          state: widget.viewModel.state,
         );
       },
     );

--- a/lib/presentation/screen/main/main_screen_root.dart
+++ b/lib/presentation/screen/main/main_screen_root.dart
@@ -14,6 +14,7 @@ class MainScreenRoot extends StatefulWidget {
   final StreamController<StreamEvent> streamController;
 
   const MainScreenRoot({
+    super.key,
     required this.viewModel,
     required this.navigationShell,
     required this.streamController,
@@ -37,6 +38,7 @@ class _MainScreenRootState extends State<MainScreenRoot> {
               context: context,
               text: e.success.message,
               icon: Icons.check,
+              typeInfo: TypeInfo.success,
             );
           case Error():
             AlertInfo.show(
@@ -44,6 +46,7 @@ class _MainScreenRootState extends State<MainScreenRoot> {
               text: e.error.message,
               icon: Icons.warning_amber,
               iconColor: AppColors.warning,
+              typeInfo: TypeInfo.error,
             );
         }
       }

--- a/lib/presentation/screen/photos/photos_view_model.dart
+++ b/lib/presentation/screen/photos/photos_view_model.dart
@@ -1,8 +1,11 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
 import 'package:photopin/core/domain/journal_photo_collection.dart';
 import 'package:photopin/core/domain/photo_journal_list_model.dart';
+import 'package:photopin/core/enums/action_type.dart';
+import 'package:photopin/core/enums/error_type.dart';
+import 'package:photopin/core/mixins/event_notifier.dart';
+import 'package:photopin/core/stream_event/stream_event.dart';
 import 'package:photopin/core/usecase/get_journal_list_use_case.dart';
 import 'package:photopin/core/usecase/get_photo_journal_list_use_case.dart';
 import 'package:photopin/core/usecase/get_photo_list_use_case.dart';
@@ -12,7 +15,7 @@ import 'package:photopin/photo/domain/model/photo_model.dart';
 import 'package:photopin/presentation/screen/photos/photos_action.dart';
 import 'package:photopin/presentation/screen/photos/photos_state.dart';
 
-class PhotosViewModel with ChangeNotifier {
+class PhotosViewModel extends EventNotifier {
   final GetPhotoListUseCase _getPhotoListUseCase;
   final GetJournalListUseCase _getJournalListUseCase;
   final GetPhotoListWithJournalIdUseCase _getPhotoListWithJournalIdUseCase;
@@ -23,6 +26,7 @@ class PhotosViewModel with ChangeNotifier {
   PhotosState _state = PhotosState();
 
   PhotosViewModel({
+    required super.streamController,
     required GetPhotoListUseCase getPhotoListUseCase,
     required GetJournalListUseCase getJournalListUseCase,
     required GetPhotoListWithJournalIdUseCase getPhotoListWithJournalIdUseCase,
@@ -43,7 +47,12 @@ class PhotosViewModel with ChangeNotifier {
   }
 
   Future<void> _photoApplyClick(PhotoModel photoModel) async {
-    await _photoRepository.updatePhoto(photoModel);
+    try {
+      await _photoRepository.updatePhoto(photoModel);
+      addEvent(const StreamEvent.success(ActionType.photoUpdate));
+    } catch (e) {
+      addEvent(const StreamEvent.error(ErrorType.photoUpdate));
+    }
   }
 
   Future<void> _photoFilterClick(int index) async {
@@ -83,7 +92,12 @@ class PhotosViewModel with ChangeNotifier {
   }
 
   Future<void> _photoDeleteClick(String photoId) async {
-    await _photoRepository.deletePhoto(photoId);
+    try {
+      await _photoRepository.deletePhoto(photoId);
+      addEvent(const StreamEvent.success(ActionType.photoDelete));
+    } catch (e) {
+      addEvent(const StreamEvent.error(ErrorType.photoDelete));
+    }
   }
 
   Future<void> init() async {
@@ -105,8 +119,7 @@ class PhotosViewModel with ChangeNotifier {
       case PhotoFilterClick():
         _photoFilterClick(action.index);
       case PhotoCardClick():
-        // TODO: Handle this case.
-        throw UnimplementedError();
+        break;
       case PhotoApplyClick():
         _photoApplyClick(action.photoModel);
       case PhotoDeleteClick():

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.54"
+  alert_info:
+    dependency: "direct main"
+    description:
+      name: alert_info
+      sha256: "618604e4a9f5943ab24073eb96e089a0319bb18fe7b4ae38c10c92b590864365"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.3"
   analyzer:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,6 +72,7 @@ dependencies:
   rxdart: ^0.28.0
   firebase_messaging: ^15.2.5
   flutter_local_notifications: ^19.2.0
+  alert_info: ^0.0.3
 
 dev_dependencies:
   flutter_test:

--- a/test/presentation/screen/home/home_view_model_test.dart
+++ b/test/presentation/screen/home/home_view_model_test.dart
@@ -5,6 +5,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:photopin/core/domain/journal_photo_collection.dart';
 import 'package:photopin/core/enums/permission_allow_status.dart';
 import 'package:photopin/core/enums/permission_type.dart';
+import 'package:photopin/core/stream_event/stream_event.dart';
 import 'package:photopin/core/usecase/get_current_user_use_case.dart';
 import 'package:photopin/core/usecase/get_journal_list_use_case.dart';
 import 'package:photopin/core/usecase/permission_check_use_case.dart';
@@ -88,6 +89,7 @@ void main() {
       permissionCheckUseCase: mockPermissionCheckUseCase,
       saveTokenUseCase: saveTokenUseCase,
       firebaseMessagingDataSource: mockFirebaseMessagingDataSource,
+      streamController: StreamController<StreamEvent>(),
     );
 
     // 가정: JournalPhotoCollection 구조에 맞게 테스트 데이터 생성


### PR DESCRIPTION
## 🔍 개요 (Summary)

- EventStream 구현
- Journal 이나 Photo 생성 변경 제거 시 이벤트 알림 구현

---

## ✅ 변경 사항 (Changes)

- evnet enum 구현
- EventNotifier 구현
- 메인, 저널, 포토, 카메라 뷰모델에 eventNotifier extends
- datasource, repository 이벤트에 try catch 추가
- alert_info 추가

---

## 📸 스크린샷 (Screenshots, 선택사항)

![image](https://github.com/user-attachments/assets/3b53195b-cdb4-4046-ae45-7cd80b77df54)

---

## 🔗 관련 이슈 (Related Issues)


Closes #224 

---


## 📝 참고 사항 (Notes)

- https://pub.dev/packages/alert_info

---

## 👀 리뷰어 체크리스트 (For Reviewer)

- [ ] 기능이 명세에 맞게 동작하는지 확인
- [ ] 불필요한 코드/주석이 없는지 확인
- [ ] 테스트가 적절히 작성되었는지 확인
