### PR TITLE
#225 feat dropdown modify

### DIFF
--- a/lib/presentation/component/photo_edit_bottom_sheet.dart
+++ b/lib/presentation/component/photo_edit_bottom_sheet.dart
@@ -156,7 +156,8 @@ class _PhotoEditBottomSheetState extends State<PhotoEditBottomSheet> {
                       ),
                       const SizedBox(width: 12),
                       Expanded(
-                        child: DropdownMenu<String>(
+                        child: // PhotoEditBottomSheet의 DropdownMenu 부분을 다음과 같이 변경
+                            DropdownMenu<String>(
                           controller: journalController,
                           inputDecorationTheme: const InputDecorationTheme(
                             contentPadding: EdgeInsets.zero,
@@ -178,16 +179,7 @@ class _PhotoEditBottomSheetState extends State<PhotoEditBottomSheet> {
                           },
                           textStyle: AppFonts.smallTextRegular,
                           dropdownMenuEntries:
-                              widget.journals.isEmpty
-                                  ? []
-                                  : List.generate(widget.journals.length, (
-                                    int index,
-                                  ) {
-                                    return DropdownMenuEntry(
-                                      label: widget.journals[index].name,
-                                      value: widget.journals[index].id,
-                                    );
-                                  }),
+                              _getFilteredJournalEntries(), // 새로운 메서드 호출
                         ),
                       ),
                     ],
@@ -229,5 +221,27 @@ class _PhotoEditBottomSheetState extends State<PhotoEditBottomSheet> {
       },
       onClosing: () {},
     );
+  }
+
+  List<DropdownMenuEntry<String>> _getFilteredJournalEntries() {
+    if (widget.journals.isEmpty) return [];
+
+    // 사진 날짜가 저널 기간에 포함되는 저널만 필터링
+    final filteredJournals =
+        widget.journals.where((journal) {
+          return widget.dateTime.isAfter(
+                journal.startDate.subtract(const Duration(days: 1)),
+              ) &&
+              widget.dateTime.isBefore(
+                journal.endDate.add(const Duration(days: 1)),
+              );
+        }).toList();
+
+    return List.generate(filteredJournals.length, (int index) {
+      return DropdownMenuEntry(
+        label: filteredJournals[index].name,
+        value: filteredJournals[index].id,
+      );
+    });
   }
 }

--- a/lib/presentation/component/photo_edit_bottom_sheet.dart
+++ b/lib/presentation/component/photo_edit_bottom_sheet.dart
@@ -156,8 +156,7 @@ class _PhotoEditBottomSheetState extends State<PhotoEditBottomSheet> {
                       ),
                       const SizedBox(width: 12),
                       Expanded(
-                        child: // PhotoEditBottomSheet의 DropdownMenu 부분을 다음과 같이 변경
-                            DropdownMenu<String>(
+                        child: DropdownMenu<String>(
                           controller: journalController,
                           inputDecorationTheme: const InputDecorationTheme(
                             contentPadding: EdgeInsets.zero,

--- a/lib/presentation/component/photo_edit_bottom_sheet.dart
+++ b/lib/presentation/component/photo_edit_bottom_sheet.dart
@@ -40,12 +40,28 @@ class _PhotoEditBottomSheetState extends State<PhotoEditBottomSheet> {
 
   String _formattedDateTime() => widget.dateTime.formatDateTimeString();
 
+  // 초기값을 저장할 변수들 추가
+  late String _initialTitle;
+  late String _initialComment;
+  late String _initialJournalId;
+
   @override
   void initState() {
     super.initState();
+    _initialTitle = widget.title;
+    _initialComment = widget.comment;
+    _initialJournalId = widget.journalId;
+
     titleController.value = TextEditingValue(text: widget.title);
     commentController.value = TextEditingValue(text: widget.comment);
     _journalId = widget.journalId;
+  }
+
+  // 변경사항이 있는지 확인하는 메서드
+  bool _hasChanges() {
+    return titleController.text != _initialTitle ||
+        commentController.text != _initialComment ||
+        _journalId != _initialJournalId;
   }
 
   @override
@@ -195,11 +211,17 @@ class _PhotoEditBottomSheetState extends State<PhotoEditBottomSheet> {
                       iconName: Icons.edit,
                       buttonName: 'Apply',
                       onClick: () {
-                        widget.onTapApply(
-                          titleController.text,
-                          _journalId,
-                          commentController.text,
-                        );
+                        if (_hasChanges()) {
+                          // 변경사항이 있을 때만 onTapApply 호출
+                          widget.onTapApply(
+                            titleController.text,
+                            _journalId,
+                            commentController.text,
+                          );
+                        } else {
+                          // 변경사항이 없으면 그냥 바텀시트 닫기
+                          widget.onTapClose();
+                        }
                       },
                     ),
                   ),

--- a/lib/presentation/screen/photos/photos_screen.dart
+++ b/lib/presentation/screen/photos/photos_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:photopin/presentation/component/confirm_dialog.dart';
 import 'package:photopin/presentation/component/journal_card_image.dart';
 import 'package:photopin/presentation/component/map_filter.dart';
 import 'package:photopin/presentation/component/photo_edit_bottom_sheet.dart';
@@ -93,7 +94,28 @@ class PhotosScreen extends StatelessWidget {
                                   Navigator.pop(context);
                                 },
                                 onTapDelete: () {
-                                  onAction(PhotosAction.deleteClick(photo.id));
+                                  showDialog(
+                                    context: context,
+                                    builder: (context) {
+                                      return ConfirmDialog(
+                                        title: '사진 삭제',
+                                        content:
+                                            '"${photo.name}" 사진을 삭제하시겠습니까? 삭제 후 되돌릴 수 없습니다.',
+                                        confirmText: '삭제',
+                                        cancelText: '취소',
+                                        onTapCancel:
+                                            () => Navigator.pop(context),
+                                        onTapConfirm: () {
+                                          onAction(
+                                            PhotosAction.deleteClick(photo.id),
+                                          );
+
+                                          Navigator.pop(context);
+                                        },
+                                      );
+                                    },
+                                  );
+
                                   Navigator.pop(context);
                                 },
                                 journals: state.journals,

--- a/lib/presentation/screen/photos/photos_screen.dart
+++ b/lib/presentation/screen/photos/photos_screen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:photopin/journal/domain/model/journal_model.dart';
+import 'package:photopin/photo/domain/model/photo_model.dart';
 import 'package:photopin/presentation/component/confirm_dialog.dart';
 import 'package:photopin/presentation/component/journal_card_image.dart';
 import 'package:photopin/presentation/component/map_filter.dart';
@@ -74,6 +76,7 @@ class PhotosScreen extends StatelessWidget {
                                 dateTime: photo.dateTime,
                                 comment: photo.comment,
                                 journalId: photo.journalId,
+                                journals: _getFilteredJournalEntries(photo),
                                 onTapClose: () => Navigator.pop(context),
                                 onTapApply: (
                                   photoName,
@@ -115,10 +118,8 @@ class PhotosScreen extends StatelessWidget {
                                       );
                                     },
                                   );
-
                                   Navigator.pop(context);
                                 },
-                                journals: state.journals,
                               );
                             },
                           );
@@ -138,5 +139,21 @@ class PhotosScreen extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  List<JournalModel> _getFilteredJournalEntries(PhotoModel photoModel) {
+    if (state.journals.isEmpty) return [];
+
+    // 사진 날짜가 저널 기간에 포함되는 저널만 필터링
+    final filteredJournals =
+        state.journals.where((journal) {
+          return photoModel.dateTime.isAfter(
+                journal.startDate.subtract(const Duration(days: 1)),
+              ) &&
+              photoModel.dateTime.isBefore(
+                journal.endDate.add(const Duration(days: 1)),
+              );
+        }).toList();
+    return filteredJournals;
   }
 }


### PR DESCRIPTION
## 🔍 개요 (Summary)

- 드랍다운에서 저널 기간에 벗어나는 사진은 들어가지 못하도록 수정
- photo screen에서 아무것도 수정하지 않고 apply를 누를 시 서버에 업데이트를 생략하고 바텀시트를 내리도록 수정
- 사진 삭제 시 모달 창을 띄워서 한 번 더 삭제 확인 절차 생성

---

## ✅ 변경 사항 (Changes)

- photoEditBottomSheet에 _getFilteredJournalEntries 메소드 생성
- initstates에 기존상태 추가
- _hasChanges로 변경 상태 체크

---

## 📸 스크린샷 (Screenshots, 선택사항)

> ![image](https://github.com/user-attachments/assets/f0498032-6f7a-43d1-bcd6-ee5b66ae0378)

---

## 🔗 관련 이슈 (Related Issues)

- Closes #225 

---

## 🧪 테스트 (Test)

- 나중에... 천천히 ...

---

## 👀 리뷰어 체크리스트 (For Reviewer)

- [ ] 기능이 명세에 맞게 동작하는지 확인
- [ ] 불필요한 코드/주석이 없는지 확인
- [ ] 테스트가 적절히 작성되었는지 확인
