### PR TITLE
#242 feat journal이 변경되었을 때만 서버에 변경 요청 전달

### DIFF
--- a/lib/journal/domain/model/journal_model.dart
+++ b/lib/journal/domain/model/journal_model.dart
@@ -26,7 +26,15 @@ class JournalModel {
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
-    return other is JournalModel && other.id == id;
+    return other is JournalModel &&
+        other.id == id &&
+        other.name == name &&
+        other.tripWith == tripWith &&
+        other.startDate == startDate &&
+        other.endDate == endDate &&
+        other.comment == comment &&
+        other.startDateMilli == startDateMilli &&
+        other.endDateMilli == endDateMilli;
   }
 
   @override

--- a/lib/presentation/component/journal_edit_bottom_sheet.dart
+++ b/lib/presentation/component/journal_edit_bottom_sheet.dart
@@ -11,7 +11,7 @@ import 'package:photopin/presentation/component/edit_bottom_sheet.dart';
 
 class JournalEditBottomSheet extends EditBottomSheet {
   final JournalModel journal;
-  final Function(JournalModel journal) onTapApply;
+  final Function(JournalModel journal, bool isChanged) onTapApply;
 
   const JournalEditBottomSheet({
     super.key,
@@ -32,6 +32,7 @@ class _JournalEditBottomSheetState extends State<JournalEditBottomSheet> {
   final TextEditingController titleController = TextEditingController();
   final TextEditingController commentController = TextEditingController();
   final TextEditingController tripWithController = TextEditingController();
+  bool hasChanges = false;
 
   late JournalModel modifiedJournal;
 
@@ -84,6 +85,9 @@ class _JournalEditBottomSheetState extends State<JournalEditBottomSheet> {
                       controller: titleController,
                       hintText: 'Write Title',
                       maxLength: 30,
+                      onChange: (String value) {
+                        modifiedJournal = modifiedJournal.copyWith(name: value);
+                      },
                     ),
                   ),
                   GestureDetector(
@@ -179,6 +183,11 @@ class _JournalEditBottomSheetState extends State<JournalEditBottomSheet> {
                           key: const Key('comment_field'),
                           controller: commentController,
                           hintText: 'Write Comment',
+                          onChange: (String value) {
+                            modifiedJournal = modifiedJournal.copyWith(
+                              comment: value,
+                            );
+                          },
                           maxLength: 30,
                         ),
                       ),
@@ -229,13 +238,11 @@ class _JournalEditBottomSheetState extends State<JournalEditBottomSheet> {
                       iconName: Icons.edit,
                       buttonName: 'Apply',
                       onClick: () {
-                        widget.onTapApply(
-                          modifiedJournal.copyWith(
-                            name: titleController.text,
-                            comment: commentController.text,
-                            tripWith: tripWith,
-                          ),
-                        );
+                        if (widget.journal != modifiedJournal) {
+                          hasChanges = true;
+                        }
+
+                        widget.onTapApply(modifiedJournal, hasChanges);
                       },
                     ),
                   ),

--- a/lib/presentation/screen/journal/journal_screen.dart
+++ b/lib/presentation/screen/journal/journal_screen.dart
@@ -105,12 +105,17 @@ class _JournalScreenState extends State<JournalScreen> {
                                 thumbnailUrl: thumbnailUrl,
                                 comment: journal.comment,
                                 onTapClose: () => Navigator.pop(context),
-                                onTapApply: (JournalModel journal) {
-                                  widget.onAction(
-                                    JournalScreenAction.onTapEdit(
-                                      journal: journal,
-                                    ),
-                                  );
+                                onTapApply: (
+                                  JournalModel journal,
+                                  bool isChanged,
+                                ) {
+                                  if (isChanged == true) {
+                                    widget.onAction(
+                                      JournalScreenAction.onTapEdit(
+                                        journal: journal,
+                                      ),
+                                    );
+                                  }
 
                                   Navigator.pop(context);
                                 },

--- a/test/presentation/component/journal_edit_bottom_sheet_test.dart
+++ b/test/presentation/component/journal_edit_bottom_sheet_test.dart
@@ -37,7 +37,8 @@ void main() {
                               comment: comment,
                               title: title,
                               thumbnailUrl: imageUrl,
-                              onTapApply: (JournalModel journal) {},
+                              onTapApply:
+                                  (JournalModel journal, bool isChanged) {},
                               onTapDelete: () {},
                               onTapClose: () {},
                               journal: journal,
@@ -93,7 +94,8 @@ void main() {
                                 journal: journal,
                                 title: title,
                                 thumbnailUrl: imageUrl,
-                                onTapApply: (JournalModel journal) {},
+                                onTapApply:
+                                    (JournalModel journal, bool isChanged) {},
                                 onTapDelete: () {},
                                 onTapClose: () {
                                   tappedClose = true;
@@ -136,6 +138,7 @@ void main() {
       await mockNetworkImagesFor(() async {
         String expectJournalName = 'N/A';
         String expectComment = 'N/A';
+        bool expectChange = false;
         List<String> expectTripWith = [];
 
         await tester.pumpWidget(
@@ -155,10 +158,14 @@ void main() {
                                 title: title,
                                 journal: journal,
                                 thumbnailUrl: imageUrl,
-                                onTapApply: (JournalModel journal) {
+                                onTapApply: (
+                                  JournalModel journal,
+                                  bool isChanged,
+                                ) {
                                   expectJournalName = journal.name;
                                   expectComment = journal.comment;
                                   expectTripWith = journal.tripWith;
+                                  expectChange = true;
                                 },
                                 onTapDelete: () {},
                                 onTapClose: () {},
@@ -209,6 +216,7 @@ void main() {
 
         expect(expectJournalName, journal.name);
         expect(expectComment, 'Sagrada');
+        expect(expectChange, true);
         expect(expectTripWith, ['최태호', '아우아']);
       });
     },
@@ -235,7 +243,8 @@ void main() {
                               title: title,
                               journal: journal,
                               thumbnailUrl: imageUrl,
-                              onTapApply: (JournalModel journal) {},
+                              onTapApply:
+                                  (JournalModel journal, bool isChanged) {},
                               onTapDelete: () {
                                 Navigator.pop(context);
                               },


### PR DESCRIPTION
## 🔍 개요 (Summary)

- `Journal`이 실제로 변경되었을 때만 서버에 변경 요청 전달
- `Journal` 모델의 동등성 비교 연산자 `==`를 수정하여 모든 값이 같으면 동등하다는 결과가 나오도록 변경

## 🔗 관련 이슈 (Related Issues)

예시:
Closes #242 

---

## 👀 리뷰어 체크리스트 (For Reviewer)

- [ ] 기능이 명세에 맞게 동작하는지 확인
- [ ] 불필요한 코드/주석이 없는지 확인
- [ ] 테스트가 적절히 작성되었는지 확인
